### PR TITLE
Fix bower metadata (missing ignore).

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "Jesús Leganés Combarro \"piranna\" <piranna@gmail.com>"
   ],
   "main": "adapter.js",
+  "ignore": [],
   "moduleType": [
     "globals"
   ],


### PR DESCRIPTION
Bower was complaining with:
 bower adapter.js#\*        invalid-meta adapter.js is missing "ignore" entry in bower.json
