### PR TITLE
Renamed bower module to webrtc-adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 [![Build Status](https://travis-ci.org/webrtc/adapter.svg)](https://travis-ci.org/webrtc/adapter)
 
-# WebRTC adapter.js #
+# WebRTC adapter #
 [adapter.js] is a shim to insulate apps from spec changes and prefix differences. In fact, the standards and protocols used for WebRTC implementations are highly stable, and there are only a few prefixed names. For full interop information, see [webrtc.org/web-apis/interop](http://www.webrtc.org/web-apis/interop).
+
+## Install ##
+#### Bower
+```bash
+bower install webrtc-adapter
+```
+#### Inclusion on Browser
+```html
+<script src="bower_components/webrtc-adapter/adapter.js"></script>
+```

--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "adapter.js",
+  "name": "webrtc-adapter",
   "description": "A shim to insulate apps from WebRTC spec changes and prefix differences",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I believe `webrtc-adapter` is a better name than the existent `adapter.js`
Not only makes the bower install more meaningful. (e.g. no one can guess what `adapter.js` package is from).
But it also removes the `.js` from the name avoiding directories with file-like names such as:
`<script src="bower_components/adapter.js/adapter.js">`
