### PR TITLE
mediaDevices.enumerateDevices() polyfill in adapter.js

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -208,9 +208,9 @@ if (navigator.mozGetUserMedia) {
     to.src = from.src;
   };
 
-  navigator.mediaDevices = navigator.mediaDevices || {
-    getUserMedia: requestUserMedia,
-    enumerateDevices: function() {
+  if (!navigator.mediaDevices) {
+    navigator.mediaDevices = {getUserMedia: requestUserMedia,
+                              enumerateDevices: function() {
       return new Promise(function(resolve) {
         var kinds = {audio: 'audioinput', video: 'videoinput'};
         return MediaStreamTrack.getSources(function(devices) {
@@ -222,8 +222,8 @@ if (navigator.mozGetUserMedia) {
           }));
         });
       });
-    }
-  };
+    }};
+  }
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }

--- a/adapter.js
+++ b/adapter.js
@@ -68,15 +68,19 @@ if (navigator.mozGetUserMedia) {
   getUserMedia = navigator.mozGetUserMedia.bind(navigator);
   navigator.getUserMedia = getUserMedia;
 
-  // Shim for MediaStreamTrack.getSources.
-  MediaStreamTrack.getSources = function(successCb) {
-    setTimeout(function() {
+  // Shim for mediaDevices on older versions.
+  if (!navigator.mediaDevices) {
+    navigator.mediaDevices = {getUserMedia: requestUserMedia};
+  }
+  navigator.mediaDevices.enumerateDevices =
+      navigator.mediaDevices.enumerateDevices || function() {
+    return new Promise(function(resolve) {
       var infos = [
-        {kind: 'audio', id: 'default', label:'', facing:''},
-        {kind: 'video', id: 'default', label:'', facing:''}
+        {kind: 'audioinput', id: 'default', label:'', groupId:''},
+        {kind: 'videoinput', id: 'default', label:'', groupId:''}
       ];
-      successCb(infos);
-    }, 0);
+      resolve(infos);
+    });
   };
 
   // Creates ICE server from the URL for FF.

--- a/adapter.js
+++ b/adapter.js
@@ -207,6 +207,23 @@ if (navigator.mozGetUserMedia) {
   reattachMediaStream = function(to, from) {
     to.src = from.src;
   };
+
+  navigator.mediaDevices = navigator.mediaDevices || {
+    getUserMedia: requestUserMedia,
+    enumerateDevices: function() {
+      return new Promise(function(resolve) {
+        var kinds = {audio: 'audioinput', video: 'videoinput'};
+        return MediaStreamTrack.getSources(function(devices) {
+          resolve(devices.map(function(device) {
+            return {label: device.label,
+                    kind: kinds[device.kind],
+                    deviceId: device.id,
+                    groupId: ''};
+          }));
+        });
+      });
+    }
+  };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }
@@ -214,18 +231,7 @@ if (navigator.mozGetUserMedia) {
 // Returns the result of getUserMedia as a Promise.
 function requestUserMedia(constraints) {
   return new Promise(function(resolve, reject) {
-    var onSuccess = function(stream) {
-      resolve(stream);
-    };
-    var onError = function(error) {
-      reject(error);
-    };
-
-    try {
-      getUserMedia(constraints, onSuccess, onError);
-    } catch (e) {
-      reject(e);
-    }
+    getUserMedia(constraints, resolve, reject);
   });
 }
 


### PR DESCRIPTION
Add a mediaDevices.enumerateDevices polyfill for Chrome using existing MediaStreamTrack.getSources().
