### PR TITLE
Publish this package to npmjs with a test package name.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "webrtc-adapter",
-  "version": "0.1.0",
-  "description": "Hide browser differences in WebRTC APIs",
+  "name": "webrtc-adapter-test",
+  "version": "0.1.1",
+  "description": "Hide browser differences in WebRTC APIs (test package name)",
   "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
-    "url": "https://github.com/w3brtc/adapter.git"
+    "url": "https://github.com/webrtc/adapter.git"
   },
   "scripts": {
     "test": "testling -x start-$BROWSER"


### PR DESCRIPTION
Another package is using the name "webrtc-adapter" on npm. In preparation
for making this the official name, we publish this version under a
different name, so that users can test before replacing the other.
