### PR TITLE
add attachMediaStream / reattachMediaStream for edge

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -290,6 +290,7 @@ if (navigator.mozGetUserMedia) {
   }
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {
+  console.log('This appears to be Edge');
   webrtcDetectedBrowser = 'edge';
 
   webrtcDetectedVersion =

--- a/adapter.js
+++ b/adapter.js
@@ -154,14 +154,8 @@ if (navigator.mozGetUserMedia) {
       });
     };
   }
-  // Attach a media stream to an element.
-  attachMediaStream = function(element, stream) {
-    console.log('Attaching media stream');
-    element.mozSrcObject = stream;
-  };
 
   reattachMediaStream = function(to, from) {
-    console.log('Reattaching media stream');
     to.mozSrcObject = from.mozSrcObject;
   };
 
@@ -283,19 +277,6 @@ if (navigator.mozGetUserMedia) {
   };
   navigator.getUserMedia = getUserMedia;
 
-  // Attach a media stream to an element.
-  attachMediaStream = function(element, stream) {
-    if (typeof element.srcObject !== 'undefined') {
-      element.srcObject = stream;
-    } else if (typeof element.mozSrcObject !== 'undefined') {
-      element.mozSrcObject = stream;
-    } else if (typeof element.src !== 'undefined') {
-      element.src = URL.createObjectURL(stream);
-    } else {
-      console.log('Error attaching stream to element.');
-    }
-  };
-
   reattachMediaStream = function(to, from) {
     to.src = from.src;
   };
@@ -326,15 +307,25 @@ if (navigator.mozGetUserMedia) {
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
 
-  attachMediaStream = function(element, stream) {
-    element.srcObject = stream;
-  };
   reattachMediaStream = function(to, from) {
     to.srcObject = from.srcObject;
   };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }
+
+// Attach a media stream to an element.
+attachMediaStream = function(element, stream) {
+  if (typeof element.srcObject !== 'undefined') {
+    element.srcObject = stream;
+  } else if (typeof element.mozSrcObject !== 'undefined') {
+    element.mozSrcObject = stream;
+  } else if (typeof element.src !== 'undefined') {
+    element.src = URL.createObjectURL(stream);
+  } else {
+    console.log('Error attaching stream to element.');
+  }
+};
 
 // Returns the result of getUserMedia as a Promise.
 function requestUserMedia(constraints) {

--- a/adapter.js
+++ b/adapter.js
@@ -154,6 +154,11 @@ if (navigator.mozGetUserMedia) {
       });
     };
   }
+
+  reattachMediaStream = function(to, from) {
+    to.mozSrcObject = from.mozSrcObject;
+  };
+
 } else if (navigator.webkitGetUserMedia) {
   console.log('This appears to be Chrome');
 
@@ -272,6 +277,10 @@ if (navigator.mozGetUserMedia) {
   };
   navigator.getUserMedia = getUserMedia;
 
+  reattachMediaStream = function(to, from) {
+    to.src = from.src;
+  };
+
   if (!navigator.mediaDevices) {
     navigator.mediaDevices = {getUserMedia: requestUserMedia,
                               enumerateDevices: function() {
@@ -298,6 +307,10 @@ if (navigator.mozGetUserMedia) {
 
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
+
+  reattachMediaStream = function(to, from) {
+    to.srcObject = from.srcObject;
+  };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }
@@ -312,19 +325,6 @@ attachMediaStream = function(element, stream) {
     element.src = URL.createObjectURL(stream);
   } else {
     console.log('Error attaching stream to element.');
-  }
-};
-
-// Attach a media stream from one element to another.
-reattachMediaStream = function(to, from) {
-  if (from.srcObject) {
-    to.srcObject = from.srcObject;
-  } else if (from.mozSrcObject) {
-    to.mozSrcObject = from.mozSrcObject;
-  } else if (from.src) {
-    to.src = from.src;
-  } else {
-    console.log('Error reattaching from one element to another.');
   }
 };
 

--- a/adapter.js
+++ b/adapter.js
@@ -316,6 +316,22 @@ if (navigator.mozGetUserMedia) {
       });
     }};
   }
+} else if (navigator.mediaDevices && navigator.userAgent.match(
+    /Edge\/(\d+).(\d+)$/)) {
+  webrtcDetectedBrowser = 'edge';
+
+  webrtcDetectedVersion =
+    parseInt(navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)[2], 10);
+
+  // the minimum version still supported by adapter.
+  webrtcMinimumVersion = 12;
+
+  attachMediaStream = function(element, stream) {
+    element.srcObject = stream;
+  };
+  reattachMediaStream = function(to, from) {
+    to.srcObject = from.srcObject;
+  };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }

--- a/adapter.js
+++ b/adapter.js
@@ -287,8 +287,6 @@ if (navigator.mozGetUserMedia) {
   attachMediaStream = function(element, stream) {
     if (typeof element.srcObject !== 'undefined') {
       element.srcObject = stream;
-    } else if (typeof element.mozSrcObject !== 'undefined') {
-      element.mozSrcObject = stream;
     } else if (typeof element.src !== 'undefined') {
       element.src = URL.createObjectURL(stream);
     } else {

--- a/adapter.js
+++ b/adapter.js
@@ -154,11 +154,6 @@ if (navigator.mozGetUserMedia) {
       });
     };
   }
-
-  reattachMediaStream = function(to, from) {
-    to.mozSrcObject = from.mozSrcObject;
-  };
-
 } else if (navigator.webkitGetUserMedia) {
   console.log('This appears to be Chrome');
 
@@ -277,10 +272,6 @@ if (navigator.mozGetUserMedia) {
   };
   navigator.getUserMedia = getUserMedia;
 
-  reattachMediaStream = function(to, from) {
-    to.src = from.src;
-  };
-
   if (!navigator.mediaDevices) {
     navigator.mediaDevices = {getUserMedia: requestUserMedia,
                               enumerateDevices: function() {
@@ -306,10 +297,6 @@ if (navigator.mozGetUserMedia) {
 
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
-
-  reattachMediaStream = function(to, from) {
-    to.srcObject = from.srcObject;
-  };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }
@@ -324,6 +311,19 @@ attachMediaStream = function(element, stream) {
     element.src = URL.createObjectURL(stream);
   } else {
     console.log('Error attaching stream to element.');
+  }
+};
+
+// Attach a media stream from one element to another.
+reattachMediaStream = function(to, from) {
+  if (from.srcObject) {
+    to.srcObject = from.srcObject;
+  } else if (from.mozSrcObject) {
+    to.mozSrcObject = from.mozSrcObject;
+  } else if (from.src) {
+    to.src = from.src;
+  } else {
+    console.log('Error reattaching from one element to another.');
   }
 };
 

--- a/adapter.js
+++ b/adapter.js
@@ -154,8 +154,14 @@ if (navigator.mozGetUserMedia) {
       });
     };
   }
+  // Attach a media stream to an element.
+  attachMediaStream = function(element, stream) {
+    console.log('Attaching media stream');
+    element.mozSrcObject = stream;
+  };
 
   reattachMediaStream = function(to, from) {
+    console.log('Reattaching media stream');
     to.mozSrcObject = from.mozSrcObject;
   };
 
@@ -277,6 +283,19 @@ if (navigator.mozGetUserMedia) {
   };
   navigator.getUserMedia = getUserMedia;
 
+  // Attach a media stream to an element.
+  attachMediaStream = function(element, stream) {
+    if (typeof element.srcObject !== 'undefined') {
+      element.srcObject = stream;
+    } else if (typeof element.mozSrcObject !== 'undefined') {
+      element.mozSrcObject = stream;
+    } else if (typeof element.src !== 'undefined') {
+      element.src = URL.createObjectURL(stream);
+    } else {
+      console.log('Error attaching stream to element.');
+    }
+  };
+
   reattachMediaStream = function(to, from) {
     to.src = from.src;
   };
@@ -308,25 +327,15 @@ if (navigator.mozGetUserMedia) {
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
 
+  attachMediaStream = function(element, stream) {
+    element.srcObject = stream;
+  };
   reattachMediaStream = function(to, from) {
     to.srcObject = from.srcObject;
   };
 } else {
   console.log('Browser does not appear to be WebRTC-capable');
 }
-
-// Attach a media stream to an element.
-attachMediaStream = function(element, stream) {
-  if (typeof element.srcObject !== 'undefined') {
-    element.srcObject = stream;
-  } else if (typeof element.mozSrcObject !== 'undefined') {
-    element.mozSrcObject = stream;
-  } else if (typeof element.src !== 'undefined') {
-    element.src = URL.createObjectURL(stream);
-  } else {
-    console.log('Error attaching stream to element.');
-  }
-};
 
 // Returns the result of getUserMedia as a Promise.
 function requestUserMedia(constraints) {


### PR DESCRIPTION
Edge supports getUserMedia as of last month: http://blogs.windows.com/msedgedev/2015/05/13/announcing-media-capture-functionality-in-microsoft-edge/

GUM works just fine, but in order to make the samples work, we need to shim attachMediaStream.
