### PR TITLE
Use RTCPeerConnection defined on the window 

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -384,7 +384,7 @@ function requestUserMedia(constraints) {
 
 if (typeof module !== 'undefined') {
   module.exports = {
-    RTCPeerConnection: RTCPeerConnection,
+    RTCPeerConnection: window.RTCPeerConnection,
     getUserMedia: getUserMedia,
     attachMediaStream: attachMediaStream,
     reattachMediaStream: reattachMediaStream,
@@ -398,7 +398,7 @@ if (typeof module !== 'undefined') {
   // Expose objects and functions when RequireJS is doing the loading.
   define([], function() {
     return {
-      RTCPeerConnection: RTCPeerConnection,
+      RTCPeerConnection: window.RTCPeerConnection,
       getUserMedia: getUserMedia,
       attachMediaStream: attachMediaStream,
       reattachMediaStream: reattachMediaStream,


### PR DESCRIPTION
... to prevent reference error in a browser where it's not defined globally. In Safari, this was throwing a `ReferenceError: Can't find variable: RTCPeerConnection` and also happened to be a linter error when I opened up the file.
