### PR TITLE
Prevent ReferenceError in node context by checking for window

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* For jshint: */
-/* globals module */
+/* globals module, require */
 
 module.exports = function(grunt) {
   grunt.initConfig({
@@ -21,11 +21,14 @@ module.exports = function(grunt) {
       }
     },
     testling: {
-      files: "test/test.js" 
-    },
+      files: 'test/test.js'
+    }
   });
 
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-jscs');
-  grunt.registerTask('default', ['jshint', 'jscs']);
+  grunt.registerTask('verify-require', 'Verifies the script can be required in a node context', function () {
+      require('./adapter');
+  });
+  grunt.registerTask('default', ['jshint', 'jscs', 'verify-require']);
 };

--- a/adapter.js
+++ b/adapter.js
@@ -38,6 +38,7 @@ function trace(text) {
 
 if (typeof window === 'undefined' || !window.navigator) {
   console.log('This does not appear to be a browser');
+  webrtcDetectedBrowser = 'not a browser';
 } else if (navigator.mozGetUserMedia) {
   console.log('This appears to be Firefox');
 
@@ -385,10 +386,8 @@ function requestUserMedia(constraints) {
 }
 
 if (typeof module !== 'undefined') {
-  var RTCPeerConnection;
-  if (typeof window === 'undefined') {
-    RTCPeerConnection = undefined;
-  } else {
+  var RTCPeerConnection = 'undefined';
+  if (typeof window !== 'undefined') {
     RTCPeerConnection = window.RTCPeerConnection;
   }
   module.exports = {

--- a/adapter.js
+++ b/adapter.js
@@ -36,7 +36,9 @@ function trace(text) {
   }
 }
 
-if (navigator.mozGetUserMedia) {
+if (typeof window === 'undefined' || !window.navigator) {
+  console.log('This does not appear to be a browser');
+} else if (navigator.mozGetUserMedia) {
   console.log('This appears to be Firefox');
 
   webrtcDetectedBrowser = 'firefox';
@@ -383,8 +385,9 @@ function requestUserMedia(constraints) {
 }
 
 if (typeof module !== 'undefined') {
+  var RTCPeerConnection = (typeof window === 'undefined') ? undefined : window.RTCPeerConnection;
   module.exports = {
-    RTCPeerConnection: window.RTCPeerConnection,
+    RTCPeerConnection: RTCPeerConnection,
     getUserMedia: getUserMedia,
     attachMediaStream: attachMediaStream,
     reattachMediaStream: reattachMediaStream,

--- a/adapter.js
+++ b/adapter.js
@@ -385,7 +385,12 @@ function requestUserMedia(constraints) {
 }
 
 if (typeof module !== 'undefined') {
-  var RTCPeerConnection = (typeof window === 'undefined') ? undefined : window.RTCPeerConnection;
+  var RTCPeerConnection;
+  if (typeof window === 'undefined') {
+    RTCPeerConnection = undefined;
+  } else {
+    RTCPeerConnection = window.RTCPeerConnection;
+  }
   module.exports = {
     RTCPeerConnection: RTCPeerConnection,
     getUserMedia: getUserMedia,


### PR DESCRIPTION
Check for window existence to allow requiring the module without error in a node context
