### PR TITLE
wrap console.log; dont log when used as a module

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -22,15 +22,16 @@ var reattachMediaStream = null;
 var webrtcDetectedBrowser = null;
 var webrtcDetectedVersion = null;
 var webrtcMinimumVersion = null;
-
-function webrtcLogger() {
-  // suppress console.log output when being included as a module
-  if (typeof module !== 'undefined' ||
-      ((typeof require === 'function') && (typeof define === 'function'))) {
-    return undefined;
+var webrtcUtils = {
+  log: function() {
+    // suppress console.log output when being included as a module.
+    if (!(typeof module !== 'undefined' ||
+        (typeof require === 'function') && (typeof define === 'function'))) { 
+      console.log.apply(console, arguments);
+    }
   }
-  return console.log.apply(console, arguments);
-}
+};
+
 
 function trace(text) {
   // This function is used for logging.
@@ -39,17 +40,17 @@ function trace(text) {
   }
   if (window.performance) {
     var now = (window.performance.now() / 1000).toFixed(3);
-    webrtcLogger(now + ': ' + text);
+    webrtcUtils.log(now + ': ' + text);
   } else {
-    webrtcLogger(text);
+    webrtcUtils.log(text);
   }
 }
 
 if (typeof window === 'undefined' || !window.navigator) {
-  webrtcLogger('This does not appear to be a browser');
+  webrtcUtils.log('This does not appear to be a browser');
   webrtcDetectedBrowser = 'not a browser';
 } else if (navigator.mozGetUserMedia) {
-  webrtcLogger('This appears to be Firefox');
+  webrtcUtils.log('This appears to be Firefox');
 
   webrtcDetectedBrowser = 'firefox';
 
@@ -130,8 +131,10 @@ if (typeof window === 'undefined' || !window.navigator) {
       }
       return c;
     };
+    webrtcUtils.log('spec: ' + JSON.stringify(c));
     c.audio = constraintsToFF37(c.audio);
     c.video = constraintsToFF37(c.video);
+    webrtcUtils.log('ff37: ' + JSON.stringify(c));
     return navigator.mozGetUserMedia(c, onSuccess, onError);
   } : navigator.mozGetUserMedia.bind(navigator);
 
@@ -178,7 +181,7 @@ if (typeof window === 'undefined' || !window.navigator) {
   };
 
 } else if (navigator.webkitGetUserMedia) {
-  webrtcLogger('This appears to be Chrome');
+  webrtcUtils.log('This appears to be Chrome');
 
   webrtcDetectedBrowser = 'chrome';
 
@@ -320,8 +323,10 @@ if (typeof window === 'undefined' || !window.navigator) {
       }
       return cc;
     };
+    webrtcUtils.log('spec:   ' + JSON.stringify(c)); // whitespace for alignment
     c.audio = constraintsToChrome(c.audio);
     c.video = constraintsToChrome(c.video);
+    webrtcUtils.log('chrome: ' + JSON.stringify(c));
     return navigator.webkitGetUserMedia(c, onSuccess, onError);
   };
   navigator.getUserMedia = getUserMedia;
@@ -333,7 +338,7 @@ if (typeof window === 'undefined' || !window.navigator) {
     } else if (typeof element.src !== 'undefined') {
       element.src = URL.createObjectURL(stream);
     } else {
-      webrtcLogger('Error attaching stream to element.');
+      webrtcUtils.log('Error attaching stream to element.');
     }
   };
 
@@ -362,7 +367,7 @@ if (typeof window === 'undefined' || !window.navigator) {
   }
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {
-  webrtcLogger('This appears to be Edge');
+  webrtcUtils.log('This appears to be Edge');
   webrtcDetectedBrowser = 'edge';
 
   webrtcDetectedVersion =
@@ -378,7 +383,7 @@ if (typeof window === 'undefined' || !window.navigator) {
     to.srcObject = from.srcObject;
   };
 } else {
-  webrtcLogger('Browser does not appear to be WebRTC-capable');
+  webrtcUtils.log('Browser does not appear to be WebRTC-capable');
 }
 
 // Returns the result of getUserMedia as a Promise.

--- a/adapter.js
+++ b/adapter.js
@@ -26,7 +26,7 @@ var webrtcUtils = {
   log: function() {
     // suppress console.log output when being included as a module.
     if (!(typeof module !== 'undefined' ||
-        (typeof require === 'function') && (typeof define === 'function'))) {
+        typeof require === 'function') && (typeof define === 'function')) {
       console.log.apply(console, arguments);
     }
   }

--- a/adapter.js
+++ b/adapter.js
@@ -26,12 +26,11 @@ var webrtcUtils = {
   log: function() {
     // suppress console.log output when being included as a module.
     if (!(typeof module !== 'undefined' ||
-        (typeof require === 'function') && (typeof define === 'function'))) { 
+        (typeof require === 'function') && (typeof define === 'function'))) {
       console.log.apply(console, arguments);
     }
   }
 };
-
 
 function trace(text) {
   // This function is used for logging.

--- a/adapter.js
+++ b/adapter.js
@@ -23,6 +23,15 @@ var webrtcDetectedBrowser = null;
 var webrtcDetectedVersion = null;
 var webrtcMinimumVersion = null;
 
+function webrtcLogger() {
+  // suppress console.log output when being included as a module
+  if (typeof module !== 'undefined' ||
+      ((typeof require === 'function') && (typeof define === 'function'))) {
+    return undefined;
+  }
+  return console.log.apply(console, arguments);
+}
+
 function trace(text) {
   // This function is used for logging.
   if (text[text.length - 1] === '\n') {
@@ -30,17 +39,17 @@ function trace(text) {
   }
   if (window.performance) {
     var now = (window.performance.now() / 1000).toFixed(3);
-    console.log(now + ': ' + text);
+    webrtcLogger(now + ': ' + text);
   } else {
-    console.log(text);
+    webrtcLogger(text);
   }
 }
 
 if (typeof window === 'undefined' || !window.navigator) {
-  console.log('This does not appear to be a browser');
+  webrtcLogger('This does not appear to be a browser');
   webrtcDetectedBrowser = 'not a browser';
 } else if (navigator.mozGetUserMedia) {
-  console.log('This appears to be Firefox');
+  webrtcLogger('This appears to be Firefox');
 
   webrtcDetectedBrowser = 'firefox';
 
@@ -121,10 +130,8 @@ if (typeof window === 'undefined' || !window.navigator) {
       }
       return c;
     };
-    console.log('spec: ' + JSON.stringify(c));
     c.audio = constraintsToFF37(c.audio);
     c.video = constraintsToFF37(c.video);
-    console.log('ff37: ' + JSON.stringify(c));
     return navigator.mozGetUserMedia(c, onSuccess, onError);
   } : navigator.mozGetUserMedia.bind(navigator);
 
@@ -163,17 +170,15 @@ if (typeof window === 'undefined' || !window.navigator) {
   }
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
-    console.log('Attaching media stream');
     element.mozSrcObject = stream;
   };
 
   reattachMediaStream = function(to, from) {
-    console.log('Reattaching media stream');
     to.mozSrcObject = from.mozSrcObject;
   };
 
 } else if (navigator.webkitGetUserMedia) {
-  console.log('This appears to be Chrome');
+  webrtcLogger('This appears to be Chrome');
 
   webrtcDetectedBrowser = 'chrome';
 
@@ -315,10 +320,8 @@ if (typeof window === 'undefined' || !window.navigator) {
       }
       return cc;
     };
-    console.log('spec:   ' + JSON.stringify(c)); // whitespace for alignment
     c.audio = constraintsToChrome(c.audio);
     c.video = constraintsToChrome(c.video);
-    console.log('chrome: ' + JSON.stringify(c));
     return navigator.webkitGetUserMedia(c, onSuccess, onError);
   };
   navigator.getUserMedia = getUserMedia;
@@ -330,7 +333,7 @@ if (typeof window === 'undefined' || !window.navigator) {
     } else if (typeof element.src !== 'undefined') {
       element.src = URL.createObjectURL(stream);
     } else {
-      console.log('Error attaching stream to element.');
+      webrtcLogger('Error attaching stream to element.');
     }
   };
 
@@ -359,7 +362,7 @@ if (typeof window === 'undefined' || !window.navigator) {
   }
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {
-  console.log('This appears to be Edge');
+  webrtcLogger('This appears to be Edge');
   webrtcDetectedBrowser = 'edge';
 
   webrtcDetectedVersion =
@@ -375,7 +378,7 @@ if (typeof window === 'undefined' || !window.navigator) {
     to.srcObject = from.srcObject;
   };
 } else {
-  console.log('Browser does not appear to be WebRTC-capable');
+  webrtcLogger('Browser does not appear to be WebRTC-capable');
 }
 
 // Returns the result of getUserMedia as a Promise.

--- a/test/test.js
+++ b/test/test.js
@@ -8,17 +8,17 @@ var test = require('tape');
 // adapter.js is not supposed to spill console.log
 // when used as a module. This temporarily overloads
 // console.log so we can assert this.
-var logcount = 0;
-var saveconsole = console.log.bind(console);
+var logCount = 0;
+var saveConsole = console.log.bind(console);
 console.log = function() {
-  logcount++;
-  saveconsole.apply(saveconsole, arguments);
+  logCount++;
+  saveConsole.apply(saveConsole, arguments);
 };
 var m = require('../adapter.js');
-console.log = saveconsole;
+console.log = saveConsole;
 
 test('log suppression', function(t) {
-  t.ok(logcount === 0, 'adapter.js does not use console.log');
+  t.ok(logCount === 0, 'adapter.js does not use console.log');
   t.end();
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,22 @@
 /* global Promise */
 var test = require('tape');
 
+// adapter.js is not supposed to spill console.log
+// when used as a module. This temporarily overloads
+// console.log so we can assert this.
+var logcount = 0;
+var saveconsole = console.log.bind(console);
+console.log = function() {
+  logcount++;
+  saveconsole.apply(saveconsole, arguments);
+};
 var m = require('../adapter.js');
+console.log = saveconsole;
+
+test('log suppression', function(t) {
+  t.ok(logcount === 0, 'adapter.js does not use console.log');
+  t.end();
+});
 
 test('Browser identified', function(t) {
   t.plan(3);


### PR DESCRIPTION
removes console.log when used in a module, fixes #68.
Also removes some inconsistent logging and debug in the resolution stuff.

Ideally we would provide modules with a way to set a logger but... maybe later.
