### PR TITLE
make sure getUserMedia var is set in Edge

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -368,6 +368,8 @@ if (typeof window === 'undefined' || !window.navigator) {
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
 
+  getUserMedia = navigator.getUserMedia;
+
   attachMediaStream = function(element, stream) {
     element.srcObject = stream;
   };


### PR DESCRIPTION
getUserMedia was never set in Edge. 
While I think we should get rid of that variable and make everyone (especially the samples, PR incoming) use navigator.getUserMedia instead, this solves the issue without requiring a major version bump.
