### PR TITLE
add promise support for getStats

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -223,7 +223,7 @@ if (typeof window === 'undefined' || !window.navigator) {
       }
 
       // promise-support
-      return new Promise(function (resolve, reject) {
+      return new Promise(function(resolve, reject) {
         nativeMethod.apply(self, [resolve, reject]);
       });
     };

--- a/adapter.js
+++ b/adapter.js
@@ -185,10 +185,12 @@ if (typeof window === 'undefined' || !window.navigator) {
   webrtcMinimumVersion = 38;
 
   // The RTCPeerConnection object.
-  window.RTCPeerConnection = window.webkitRTCPeerConnection;
+  window.RTCPeerConnection = function(pcConfig, pcConstraints) {
+    return new webkitRTCPeerConnection(pcConfig, pcConstraints);
+  }
 
   // fix getStats
-  ['getStats'].forEach(function(method) {
+  ['getStats'].forEach(function(method) { // jshint ignore: line
     var nativeMethod = webkitRTCPeerConnection.prototype[method];
     webkitRTCPeerConnection.prototype[method] = function() {
       var self = this;

--- a/adapter.js
+++ b/adapter.js
@@ -193,7 +193,8 @@ if (typeof window === 'undefined' || !window.navigator) {
     webkitRTCPeerConnection.prototype[method] = function() {
       var self = this;
       var args = arguments;
-      if (typeof arguments[0] === 'function') {
+
+      if (arguments.length > 0 && typeof arguments[0] === 'function') {
         return nativeMethod.apply(this, arguments);
       }
       var fixChromeStats = function(response) {
@@ -213,10 +214,18 @@ if (typeof window === 'undefined' || !window.navigator) {
 
         return standardReport;
       };
-      var successCallbackWrapper = function(response) {
-        args[1](fixChromeStats(response));
-      };
-      return nativeMethod.apply(this, [successCallbackWrapper, arguments[0]]);
+      if (arguments.length >= 2) {
+        var successCallbackWrapper = function(response) {
+          args[1](fixChromeStats(response));
+        };
+
+        return nativeMethod.apply(this, [successCallbackWrapper, arguments[0]]);
+      }
+
+      // promise-support
+      return new Promise(function (resolve, reject) {
+        nativeMethod.apply(self, [resolve, reject]);
+      });
     };
   });
 

--- a/test/test.js
+++ b/test/test.js
@@ -297,5 +297,5 @@ test('getStats promise', function(t) {
   t.ok(typeof p === 'object', 'getStats with no arguments returns a Promise');
 
   var q = pc1.getStats(null);
-  t.ok(typeof p === 'object', 'getStats with a selector returns a Promise');
+  t.ok(typeof q === 'object', 'getStats with a selector returns a Promise');
 });

--- a/test/test.js
+++ b/test/test.js
@@ -288,3 +288,14 @@ test('originalChromeGetStats', function(t) {
     t.end();
   }
 });
+
+test('getStats promise', function(t) {
+  t.plan(2);
+  var pc1 = new m.RTCPeerConnection(null);
+
+  var p = pc1.getStats();
+  t.ok(typeof p === 'object', 'getStats with no arguments returns a Promise');
+
+  var q = pc1.getStats(null);
+  t.ok(typeof p === 'object', 'getStats with a selector returns a Promise');
+});


### PR DESCRIPTION
taking a stab a promise support for getStats... see https://github.com/w3c/webrtc-pc/pull/235 for the spec.

Overloading arguments in JS is slightly tricky but I think this will also remove the problem with #41 which was reintroduced with the awesome getStats shim.

Firefox added this in FF37 according to @jan-ivar and technically the minimum version of FF supported by adapter is currently 31... I don't really feel like supporting that though so let's bump the min version here?
