### PR TITLE
Fix add/removeEventListener for Chrome unstable

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -353,9 +353,18 @@ if (typeof window === 'undefined' || !window.navigator) {
         });
       });
     }};
-    // in case someone wants to listen for the devicechange event.
-    navigator.mediaDevices.addEventListener = function() { };
-    navigator.mediaDevices.removeEventListener = function() { };
+  }
+  // Dummy devicechange event methods.
+  // TODO(KaptenJansson) remove once implemented in Chrome stable.
+  if (typeof navigator.mediaDevices.addEventListener === 'undefined') {
+    navigator.mediaDevices.addEventListener = function() {
+      console.log('Dummy mediaDevices.addEventListener OK');
+    };
+  }
+  if (typeof navigator.mediaDevices.removeEventListener === 'undefined') {
+    navigator.mediaDevices.removeEventListener = function() {
+      console.log('Dummy mediaDevices.removeEventListener OK');
+    };
   }
 } else if (navigator.mediaDevices && navigator.userAgent.match(
     /Edge\/(\d+).(\d+)$/)) {

--- a/adapter.js
+++ b/adapter.js
@@ -358,12 +358,12 @@ if (typeof window === 'undefined' || !window.navigator) {
   // TODO(KaptenJansson) remove once implemented in Chrome stable.
   if (typeof navigator.mediaDevices.addEventListener === 'undefined') {
     navigator.mediaDevices.addEventListener = function() {
-      console.log('Dummy mediaDevices.addEventListener OK');
+      console.log('Dummy mediaDevices.addEventListener called.');
     };
   }
   if (typeof navigator.mediaDevices.removeEventListener === 'undefined') {
     navigator.mediaDevices.removeEventListener = function() {
-      console.log('Dummy mediaDevices.removeEventListener OK');
+      console.log('Dummy mediaDevices.removeEventListener called.');
     };
   }
 } else if (navigator.mediaDevices && navigator.userAgent.match(


### PR DESCRIPTION
This fixes the Chrome unstable navigator.mediaDevices.addEventListener tests even though they only check that the function exists.

@alvestrand, @fippo Not sure about the log text, any ideas?

NOTE: I will update console.log to use whatever is decided in #74.

Fixes #73
