### PR TITLE
Add shim for navigator.mediaDevices.getUserMedia when mediaDevices exist

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -354,6 +354,15 @@ if (typeof window === 'undefined' || !window.navigator) {
       });
     }};
   }
+
+  // A shim for getUserMedia method on the mediaDevices object.
+  // TODO(KaptenJansson) remove once in implented in Chrome stable.
+  if (!navigator.mediaDevices.getUserMedia) {
+    navigator.mediaDevices.getUserMedia = function(constraints) {
+      return requestUserMedia(constraints);
+    };
+  }
+
   // Dummy devicechange event methods.
   // TODO(KaptenJansson) remove once implemented in Chrome stable.
   if (typeof navigator.mediaDevices.addEventListener === 'undefined') {

--- a/test/test.js
+++ b/test/test.js
@@ -218,7 +218,7 @@ test('call enumerateDevices', function(t) {
   });
 });
 
-// test that adding and removing an eventlistener on navigator.mediaDevices
+// Test that adding and removing an eventlistener on navigator.mediaDevices
 // is possible. The usecase for this is the devicechanged event.
 // This does not test whether devicechanged is actually called.
 test('navigator.mediaDevices eventlisteners', function(t) {
@@ -227,6 +227,19 @@ test('navigator.mediaDevices eventlisteners', function(t) {
       'navigator.mediaDevices.addEventListener is a function');
   t.ok(typeof(navigator.mediaDevices.removeEventListener) === 'function',
       'navigator.mediaDevices.removeEventListener is a function');
+});
+
+// Test that getUserMedia is shimmed properly.
+test('navigator.mediaDevices.getUserMedia', function(t) {
+  navigator.mediaDevices.getUserMedia({video: true, fake: true})
+  .then(function(stream) {
+    t.ok(stream.getVideoTracks().length > 0, 'Got stream with video tracks.');
+    t.end();
+  })
+  .catch(function(err) {
+    t.fail('getUserMedia failed with error: ' + err.toString());
+    t.end();
+  });
 });
 
 // Test Chrome polyfill for getStats.


### PR DESCRIPTION
Fixes `Uncaught TypeError: navigator.mediaDevices.getUserMedia is not a function` currently seen in latest samples push, e.g. http://webrtc.github.io/samples/src/content/peerconnection/webaudio-input/ when using `--enable-blink-features=EnumerateDevices,AudioOutputDevices` flag on 45.0.2441.3 or later.

@alvestrand PTAL
