### PR TITLE
add firefox extended support release to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - BROWSER=firefox BVER=stable
     - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=unstable
+    - BROWSER=firefox BVER=esr
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This adds Firefox ESR (https://www.mozilla.org/en-US/firefox/organizations/faq/) to the test matrix.

Local node_modules might have to be wiped, npm ls should show djo-shell as 1.4.0
I wonder if we should bump the minimum supported version of Firefox to that... it's better to test things instead of just intending them.
