### PR TITLE
make npm add run-tests to node_modules/bin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
   },
+  "bin": {
+    "run-tests": "./test/run-test"
+  },
   "scripts": {
     "test": "test/run-tests"
   },


### PR DESCRIPTION
this should add run-tests to node_modules/.bin/ so we don't have to duplicate it in the samples (and I don't have to duplicate it in a number of my own repos)
