### PR TITLE
Skip constraint test on firefox <42 (fixes travis regression)

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,7 @@ test('call getUserMedia with constraints', function(t) {
   };
   if (m.webrtcDetectedBrowser === 'firefox') {
     if (m.webrtcDetectedVersion < 42) {
-      t.skip('getUserMedia(impossibleConstraints) must fail (firefox <42 can't turn off fake devices)');
+      t.skip('getUserMedia(impossibleConstraints) must fail (firefox <42 cannot turn off fake devices)');
       return;
     }
     impossibleConstraints.fake = false; // override

--- a/test/test.js
+++ b/test/test.js
@@ -84,6 +84,7 @@ test('attachMediaStream', function(t) {
 });
 
 test('call getUserMedia with constraints', function(t) {
+  t.plan(1);
   var impossibleConstraints = {
     video: {
       width: 1280,
@@ -91,17 +92,21 @@ test('call getUserMedia with constraints', function(t) {
       frameRate: {exact: 0} // to fail
     },
   };
+  if (m.webrtcDetectedBrowser === 'firefox') {
+    if (m.webrtcDetectedVersion < 42) {
+      t.skip("getUserMedia(impossibleConstraints) must fail (firefox <42 can't turn off fake devices)");
+      return;
+    }
+    impossibleConstraints.fake = false; // override
+  }
   new Promise(function(resolve, reject) {
     navigator.getUserMedia(impossibleConstraints, resolve, reject);
   })
   .then(function() {
     t.fail('getUserMedia(impossibleConstraints) must fail');
-    t.end();
   })
   .catch(function(err) {
-    t.pass('getUserMedia(impossibleConstraints) must fail');
-    t.ok(err.name.indexOf('Error') >= 0, 'must fail with named Error');
-    t.end();
+    t.ok(err.name.indexOf('Error') >= 0, 'getUserMedia(impossibleConstraints) must fail');
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,8 @@ test('call getUserMedia with constraints', function(t) {
   };
   if (m.webrtcDetectedBrowser === 'firefox') {
     if (m.webrtcDetectedVersion < 42) {
-      t.skip('getUserMedia(impossibleConstraints) must fail (firefox <42 cannot turn off fake devices)');
+      t.skip('getUserMedia(impossibleConstraints) must fail ' +
+             '(firefox <42 cannot turn off fake devices)');
       return;
     }
     impossibleConstraints.fake = false; // override
@@ -106,7 +107,8 @@ test('call getUserMedia with constraints', function(t) {
     t.fail('getUserMedia(impossibleConstraints) must fail');
   })
   .catch(function(err) {
-    t.ok(err.name.indexOf('Error') >= 0, 'getUserMedia(impossibleConstraints) must fail');
+    t.ok(err.name.indexOf('Error') >= 0,
+         'getUserMedia(impossibleConstraints) must fail');
   });
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -94,7 +94,7 @@ test('call getUserMedia with constraints', function(t) {
   };
   if (m.webrtcDetectedBrowser === 'firefox') {
     if (m.webrtcDetectedVersion < 42) {
-      t.skip("getUserMedia(impossibleConstraints) must fail (firefox <42 can't turn off fake devices)");
+      t.skip('getUserMedia(impossibleConstraints) must fail (firefox <42 can't turn off fake devices)');
       return;
     }
     impossibleConstraints.fake = false; // override


### PR DESCRIPTION
Fixes failures on https://travis-ci.org/webrtc/adapter/jobs/71994516#L414 which were introduced by https://github.com/DamonOehlman/travis-multirunner/pull/7

The problem is that firefox's fake devices don't ([yet](https://bugzilla.mozilla.org/show_bug.cgi?id=1182938)) support constraints, and there's no way to turn off fake devices Firefox <42.

The test still runs on 42+ and on Chrome.
