### PR TITLE
translate iceTransportPolicy to iceTransports

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -210,6 +210,12 @@ if (typeof window === 'undefined' || !window.navigator) {
 
   // The RTCPeerConnection object.
   window.RTCPeerConnection = function(pcConfig, pcConstraints) {
+    // Translate iceTransportPolicy to iceTransports,
+    // see https://code.google.com/p/webrtc/issues/detail?id=4869
+    if (pcConfig && pcConfig.iceTransportPolicy) {
+      pcConfig.iceTransports = pcConfig.iceTransportPolicy;
+    }
+
     var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints);
     var origGetStats = pc.getStats.bind(pc);
     pc.getStats = function(selector, successCallback, errorCallback) { // jshint ignore: line

--- a/test/test.js
+++ b/test/test.js
@@ -587,7 +587,8 @@ test('iceTransportPolicy is translated to iceTransports', function(t) {
     t.pass('iceTransportPolicy is not implemented by Firefox yet.');
     t.end();
   }
-  var pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay', iceServers: []});
+  var pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay',
+      iceServers: []});
 
   // Since we try to gather only relay candidates without specifying
   // a TURN server, we should not get any candidates.
@@ -601,7 +602,7 @@ test('iceTransportPolicy is translated to iceTransports', function(t) {
         t.fail('got unexpected candidates. ' + JSON.stringify(candidates));
       }
     } else {
-      candidates.push(event.candidate); 
+      candidates.push(event.candidate);
     }
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -580,35 +580,3 @@ test('getStats promise', function(t) {
   var q = pc1.getStats(null);
   t.ok(typeof q === 'object', 'getStats with a selector returns a Promise');
 });
-
-test('iceTransportPolicy is translated to iceTransports', function(t) {
-  if (m.webrtcDetectedBrowser === 'firefox') {
-    // not implemented yet.
-    t.pass('iceTransportPolicy is not implemented by Firefox yet.');
-    t.end();
-  }
-  var pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay',
-      iceServers: []});
-
-  // Since we try to gather only relay candidates without specifying
-  // a TURN server, we should not get any candidates.
-  var candidates = [];
-  pc1.createDataChannel('somechannel');
-  pc1.onicecandidate = function(event) {
-    if (!event.candidate) {
-      if (candidates.length === 0) {
-        t.pass('iceTransportPolicy was translated to iceTransport');
-      } else {
-        t.fail('got unexpected candidates. ' + JSON.stringify(candidates));
-      }
-    } else {
-      candidates.push(event.candidate);
-    }
-  };
-
-  pc1.createOffer().then(function(offer) {
-    return pc1.setLocalDescription(offer);
-  }).catch(function(err) {
-    t.fail(err.toString());
-  });
-});


### PR DESCRIPTION
until https://code.google.com/p/webrtc/issues/detail?id=4869 is fixed I don't want to write code that works around the wrong name if I can just get it fixed in adapter.
The two things using this are the candidate gathering sample and apprtc (?it=relay)

The test is indirect. If the policy is set and we try to gather candidates without a TURN server, we will not get any candidates.
Firefox is not supported yet so the test passes. @jan-ivar I failed to find a bugzilla id for this?
