### PR TITLE
Setting version 0.8.1 of grunt-jscs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "^0.9.1",
-    "grunt-jscs": ">=0.8.1",
+    "grunt-jscs": "^0.8.1",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
     "travis-multirunner": "^2.6.0"


### PR DESCRIPTION
grunt-jscs": ">=0.8.1" allowed version 2.0 to be installed, which is as expected, but for some reason it seems that either that the Google preset is not working or it has changed.

Anyway setting grunt-jscs": "^0.8.1" version for now until we have figured it out.
