### PR TITLE
Fix style, .gitignore and bump to jscs2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+browsers/
 node_modules/
 *~

--- a/adapter.js
+++ b/adapter.js
@@ -87,7 +87,7 @@ if (typeof window === 'undefined' || !window.navigator) {
         pcConfig.iceServers = newIceServers;
       }
     }
-    return new mozRTCPeerConnection(pcConfig, pcConstraints);
+    return new mozRTCPeerConnection(pcConfig, pcConstraints); // jscs:ignore requireCapitalizedConstructors
   };
 
   // The RTCSessionDescription object.
@@ -167,8 +167,8 @@ if (typeof window === 'undefined' || !window.navigator) {
       navigator.mediaDevices.enumerateDevices || function() {
     return new Promise(function(resolve) {
       var infos = [
-        {kind: 'audioinput', deviceId: 'default', label:'', groupId:''},
-        {kind: 'videoinput', deviceId: 'default', label:'', groupId:''}
+        {kind: 'audioinput', deviceId: 'default', label: '', groupId: ''},
+        {kind: 'videoinput', deviceId: 'default', label: '', groupId: ''}
       ];
       resolve(infos);
     });
@@ -216,7 +216,7 @@ if (typeof window === 'undefined' || !window.navigator) {
       pcConfig.iceTransports = pcConfig.iceTransportPolicy;
     }
 
-    var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints);
+    var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints); // jscs:ignore requireCapitalizedConstructors
     var origGetStats = pc.getStats.bind(pc);
     pc.getStats = function(selector, successCallback, errorCallback) { // jshint ignore: line
       var self = this;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-nodeunit": "~0.4.1",
     "grunt-contrib-uglify": "^0.9.1",
-    "grunt-jscs": "^0.8.1",
+    "grunt-jscs": "^2.0.0",
     "tape": "^4.0.0",
     "testling": "^1.7.1",
     "travis-multirunner": "^2.6.0"

--- a/test/test.js
+++ b/test/test.js
@@ -155,7 +155,7 @@ test('check getUserMedia legacy constraints converter', function(t) {
         [
          {
            video: {
-             mediaSource:'screen',
+             mediaSource: 'screen',
              width: 1280,
              height: {min: 200, ideal: 720, max: 1080},
              facingMode: 'user',
@@ -164,15 +164,15 @@ test('check getUserMedia legacy constraints converter', function(t) {
          },
          {
            video: {
-             mediaSource:'screen',
-             height: {min: 200, max:1080},
+             mediaSource: 'screen',
+             height: {min: 200, max: 1080},
              frameRate: {max: 50, min: 50},
-             advanced:[
+             advanced: [
                {width: {min: 1280, max: 1280}},
                {height: {min: 720, max: 720}},
                {facingMode: 'user'}
              ],
-             require:['height', 'frameRate']
+             require: ['height', 'frameRate']
            }
          }
         ],
@@ -180,26 +180,26 @@ test('check getUserMedia legacy constraints converter', function(t) {
         [
          {
            video: {
-             height: {min: 200, max:1080},
+             height: {min: 200, max: 1080},
              frameRate: {max: 50, min: 50},
-             advanced:[
+             advanced: [
                {width: {min: 1280, max: 1280}},
                {height: {min: 720, max: 720}},
                {facingMode: 'user'}
              ],
-             require:['height', 'frameRate']
+             require: ['height', 'frameRate']
            }
          },
          {
            video: {
-             height: {min: 200, max:1080},
+             height: {min: 200, max: 1080},
              frameRate: {max: 50, min: 50},
-             advanced:[
+             advanced: [
                {width: {min: 1280, max: 1280}},
                {height: {min: 720, max: 720}},
                {facingMode: 'user'}
              ],
-             require:['height', 'frameRate']
+             require: ['height', 'frameRate']
            }
          }
         ],
@@ -211,7 +211,7 @@ test('check getUserMedia legacy constraints converter', function(t) {
         [
          {
            video: {
-             mediaSource:'screen',
+             mediaSource: 'screen',
              width: 1280,
              height: {min: 200, ideal: 720, max: 1080},
              facingMode: 'user',
@@ -220,7 +220,7 @@ test('check getUserMedia legacy constraints converter', function(t) {
          },
          {
            video: {
-             mediaSource:'screen',
+             mediaSource: 'screen',
              width: 1280,
              height: {min: 200, ideal: 720, max: 1080},
              facingMode: 'user',
@@ -297,11 +297,11 @@ test('check getUserMedia legacy constraints converter', function(t) {
       [
        {
          video: {
-           mediaSource:'screen',
-           advanced:[
+           mediaSource: 'screen',
+           advanced: [
              {facingMode: 'user'}
            ],
-           require:['height', 'frameRate']
+           require: ['height', 'frameRate']
          }
        },
        {


### PR DESCRIPTION
We have to ofc ignore the capitalization check for the prefixed constructors.

Fixes #99 
