### PR TITLE
shim srcObject

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -442,10 +442,20 @@ if (typeof window === 'undefined' || !window.navigator) {
 
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
-    element.srcObject = stream;
+    if (webrtcDetectedVersion >= 43) {
+      element.srcObject = stream;
+    } else if (typeof element.src !== 'undefined') {
+      element.src = URL.createObjectURL(stream);
+    } else {
+      webrtcUtils.log('Error attaching stream to element.');
+    }
   };
   reattachMediaStream = function(to, from) {
-    to.srcObject = from.srcObject;
+    if (webrtcDetectedVersion >= 43) {
+      to.srcObject = from.srcObject;
+    } else {
+      to.src = from.src;
+    }
   };
 
 } else if (navigator.mediaDevices && navigator.userAgent.match(

--- a/adapter.js
+++ b/adapter.js
@@ -187,13 +187,22 @@ if (typeof window === 'undefined' || !window.navigator) {
       });
     };
   }
+
+  Object.defineProperty(HTMLVideoElement.prototype, 'srcObject', {
+    get: function() {
+      return this.mozSrcObject;
+    },
+    set: function(stream) {
+      this.mozSrcObject = stream;
+    }
+  });
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
-    element.mozSrcObject = stream;
+    element.srcObject = stream;
   };
 
   reattachMediaStream = function(to, from) {
-    to.mozSrcObject = from.mozSrcObject;
+    to.srcObject = from.srcObject;
   };
 
 } else if (navigator.webkitGetUserMedia) {
@@ -420,19 +429,19 @@ if (typeof window === 'undefined' || !window.navigator) {
     };
   }
 
+  Object.defineProperty(HTMLVideoElement.prototype, 'srcObject', {
+    set: function(stream) {
+      this.src = URL.createObjectURL(stream);
+    }
+    // TODO: get: function() { ... }
+  });
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
-    if (typeof element.srcObject !== 'undefined') {
-      element.srcObject = stream;
-    } else if (typeof element.src !== 'undefined') {
-      element.src = URL.createObjectURL(stream);
-    } else {
-      webrtcUtils.log('Error attaching stream to element.');
-    }
+    element.srcObject = stream;
   };
 
   reattachMediaStream = function(to, from) {
-    to.src = from.src;
+    to.src = from.src; // FIXME
   };
 
 } else if (navigator.mediaDevices && navigator.userAgent.match(

--- a/adapter.js
+++ b/adapter.js
@@ -430,18 +430,22 @@ if (typeof window === 'undefined' || !window.navigator) {
   }
 
   Object.defineProperty(HTMLVideoElement.prototype, 'srcObject', {
+    get: function() {
+      return this._srcObject;
+    },
     set: function(stream) {
+      // TODO: use revokeObjectURL is src is set and stream is null?
+      this._srcObject = stream;
       this.src = URL.createObjectURL(stream);
     }
-    // TODO: get: function() { ... }
   });
+
   // Attach a media stream to an element.
   attachMediaStream = function(element, stream) {
     element.srcObject = stream;
   };
-
   reattachMediaStream = function(to, from) {
-    to.src = from.src; // FIXME
+    to.srcObject = from.srcObject;
   };
 
 } else if (navigator.mediaDevices && navigator.userAgent.match(

--- a/test/test.js
+++ b/test/test.js
@@ -157,6 +157,7 @@ test('video srcObject getter/setter test', function(t) {
     t.ok(video.srcObject.id === stream.id,
         'srcObject getter returns stream object');
     // FIXME: add a video.srcObject = null here?
+    stream.getTracks().forEach(function(track) { track.stop(); });
   })
   .catch(function(err) {
     t.fail(err.toString());
@@ -175,6 +176,7 @@ test('srcObject set from another object', function(t) {
     video2.srcObject = video.srcObject;
     t.ok(video.srcObject.id === video2.srcObject.id,
         'stream ids from srcObjects match');
+    stream.getTracks().forEach(function(track) { track.stop(); });
     t.end();
   })
   .catch(function(err) {
@@ -187,19 +189,20 @@ test('attach mediaStream directly', function(t) {
   t.plan((m.webrtcDetectedBrowser === 'firefox' &&
           m.webrtcDetectedVersion < 38) ? 2 : 3);
   var video = document.createElement('video');
-  // If attachMediaStream works, we should get a video
-  // at some point. This will trigger onloadedmetadata.
-  video.onloadedmetadata = function() {
-    t.pass('got stream with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-  };
-
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {
     t.pass('got stream.');
     video.srcObject = stream;
     t.pass('attachMediaStream returned');
+
+    // If attachMediaStream works, we should get a video
+    // at some point. This will trigger onloadedmetadata.
+    video.onloadedmetadata = function() {
+      t.pass('got stream with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+      stream.getTracks().forEach(function(track) { track.stop(); });
+    };
   })
   .catch(function(err) {
     t.fail(err.toString());
@@ -211,28 +214,28 @@ test('reattaching mediaStream directly', function(t) {
   t.plan((m.webrtcDetectedBrowser === 'firefox' &&
           m.webrtcDetectedVersion < 38) ? 2 : 4);
   var video = document.createElement('video');
-  // If attachMediaStream works, we should get a video
-  // at some point. This will trigger onloadedmetadata.
-  // This reattaches to the second video which will trigger
-  // onloadedmetadata there.
-  video.onloadedmetadata = function() {
-    t.pass('got stream on first video with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-    video2.srcObject = video.srcObject;
-  };
-
-  var video2 = document.createElement('video');
-  video2.onloadedmetadata = function() {
-    t.pass('got stream on second video with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-  };
-
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {
     t.pass('got stream.');
     video.srcObject = stream;
     t.pass('srcObject set');
+
+    // If attachMediaStream works, we should get a video
+    // at some point. This will trigger onloadedmetadata.
+    // This reattaches to the second video which will trigger
+    // onloadedmetadata there.
+    video.onloadedmetadata = function() {
+      t.pass('got stream on first video with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+      video2.srcObject = video.srcObject;
+    };
+
+    var video2 = document.createElement('video');
+    video2.onloadedmetadata = function() {
+      t.pass('got stream on second video with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+    };
   })
   .catch(function(err) {
     t.fail(err.toString());

--- a/test/test.js
+++ b/test/test.js
@@ -108,6 +108,138 @@ test('attachMediaStream', function(t) {
   });
 });
 
+test('reattachMediaStream', function(t) {
+  // onloadedmetadata had issues in Firefox < 38.
+  t.plan((m.webrtcDetectedBrowser === 'firefox' &&
+          m.webrtcDetectedVersion < 38) ? 2 : 4);
+  var video = document.createElement('video');
+  video.id = 'video1';
+
+  // if attachMediaStream works, we should get a video
+  // at some point. This will trigger onloadedmetadata
+  // This reattaches to the second video which will trigger
+  // onloadedmetadata there.
+  video.onloadedmetadata = function() {
+    t.pass('got stream on first video with w=' + video.videoWidth +
+           ',h=' + video.videoHeight);
+    m.reattachMediaStream(video2, video);
+  };
+
+  var video2 = document.createElement('video');
+  video2.id = 'video2';
+  video2.onloadedmetadata = function() {
+    t.pass('got stream on second video with w=' + video.videoWidth +
+           ',h=' + video.videoHeight);
+  }
+
+  var constraints = {video: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream.');
+    m.attachMediaStream(video, stream);
+    t.pass('srcObject set');
+    console.log(video.srcObject.id);
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
+test('video srcObject getter/setter test', function(t) {
+  t.plan(3);
+  var video = document.createElement('video');
+
+  var constraints = {video: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream.');
+    video.srcObject = stream;
+    t.pass('srcObject set');
+    t.ok(video.srcObject.id === stream.id,
+        'srcObject getter returns stream object');
+    // FIXME: add a video.srcObject = null here?
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
+test('srcObject set from another object', function(t) {
+  var video = document.createElement('video');
+  var video2 = document.createElement('video');
+
+  var constraints = {video: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream.');
+    video.srcObject = stream;
+    video2.srcObject = video.srcObject;
+    t.ok(video.srcObject.id === video2.srcObject.id, 'stream ids from srcObjects match');
+    t.end();
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
+test('attach mediaStream directly', function(t) {
+  // onloadedmetadata had issues in Firefox < 38.
+  t.plan((m.webrtcDetectedBrowser === 'firefox' &&
+          m.webrtcDetectedVersion < 38) ? 2 : 3);
+  var video = document.createElement('video');
+  // if attachMediaStream works, we should get a video
+  // at some point. This will trigger onloadedmetadata.
+  video.onloadedmetadata = function() {
+    t.pass('got stream with w=' + video.videoWidth +
+           ',h=' + video.videoHeight);
+  };
+
+  var constraints = {video: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream.');
+    video.srcObject = stream;
+    t.pass('attachMediaStream returned');
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
+test('reattaching mediaStream directly', function(t) {
+  // onloadedmetadata had issues in Firefox < 38.
+  t.plan((m.webrtcDetectedBrowser === 'firefox' &&
+          m.webrtcDetectedVersion < 38) ? 2 : 4);
+  var video = document.createElement('video');
+  // if attachMediaStream works, we should get a video
+  // at some point. This will trigger onloadedmetadata
+  // This reattaches to the second video which will trigger
+  // onloadedmetadata there.
+  video.onloadedmetadata = function() {
+    t.pass('got stream on first video with w=' + video.videoWidth +
+           ',h=' + video.videoHeight);
+    video2.srcObject = video.srcObject;
+  };
+
+  var video2 = document.createElement('video');
+  video2.onloadedmetadata = function() {
+    t.pass('got stream on second video with w=' + video.videoWidth +
+           ',h=' + video.videoHeight);
+  }
+
+  var constraints = {video: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream.');
+    video.srcObject = stream;
+    t.pass('srcObject set');
+    console.log(video.srcObject.id);
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
 test('call getUserMedia with constraints', function(t) {
   t.plan(1);
   var impossibleConstraints = {

--- a/test/test.js
+++ b/test/test.js
@@ -88,18 +88,18 @@ test('attachMediaStream', function(t) {
   // onloadedmetadata had issues in Firefox < 38.
   t.plan((m.webrtcDetectedBrowser === 'firefox' &&
           m.webrtcDetectedVersion < 38) ? 2 : 3);
-  var video = document.createElement('video');
-  // if attachMediaStream works, we should get a video
-  // at some point. This will trigger onloadedmetadata.
-  video.onloadedmetadata = function() {
-    t.pass('got stream with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-  };
-
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {
     t.pass('got stream.');
+    var video = document.createElement('video');
+    // if attachMediaStream works, we should get a video
+    // at some point. This will trigger onloadedmetadata.
+    video.onloadedmetadata = function() {
+      t.pass('got stream with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+      stream.getTracks().forEach(function(track) { track.stop(); });
+    };
     m.attachMediaStream(video, stream);
     t.pass('attachMediaStream returned');
   })
@@ -112,30 +112,29 @@ test('reattachMediaStream', function(t) {
   // onloadedmetadata had issues in Firefox < 38.
   t.plan((m.webrtcDetectedBrowser === 'firefox' &&
           m.webrtcDetectedVersion < 38) ? 2 : 4);
-  var video = document.createElement('video');
-  video.id = 'video1';
-
-  // if attachMediaStream works, we should get a video
-  // at some point. This will trigger onloadedmetadata
-  // This reattaches to the second video which will trigger
-  // onloadedmetadata there.
-  video.onloadedmetadata = function() {
-    t.pass('got stream on first video with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-    m.reattachMediaStream(video2, video);
-  };
-
-  var video2 = document.createElement('video');
-  video2.id = 'video2';
-  video2.onloadedmetadata = function() {
-    t.pass('got stream on second video with w=' + video.videoWidth +
-           ',h=' + video.videoHeight);
-  };
-
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)
   .then(function(stream) {
     t.pass('got stream.');
+    var video = document.createElement('video');
+
+    // if attachMediaStream works, we should get a video
+    // at some point. This will trigger onloadedmetadata
+    // This reattaches to the second video which will trigger
+    // onloadedmetadata there.
+    video.onloadedmetadata = function() {
+      t.pass('got stream on first video with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+      m.reattachMediaStream(video2, video);
+    };
+
+    var video2 = document.createElement('video');
+    video2.onloadedmetadata = function() {
+      t.pass('got stream on second video with w=' + video.videoWidth +
+             ',h=' + video.videoHeight);
+      stream.getTracks().forEach(function(track) { track.stop(); });
+    };
+
     m.attachMediaStream(video, stream);
     t.pass('srcObject set');
     console.log(video.srcObject.id);

--- a/test/test.js
+++ b/test/test.js
@@ -130,7 +130,7 @@ test('reattachMediaStream', function(t) {
   video2.onloadedmetadata = function() {
     t.pass('got stream on second video with w=' + video.videoWidth +
            ',h=' + video.videoHeight);
-  }
+  };
 
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)
@@ -174,7 +174,8 @@ test('srcObject set from another object', function(t) {
     t.pass('got stream.');
     video.srcObject = stream;
     video2.srcObject = video.srcObject;
-    t.ok(video.srcObject.id === video2.srcObject.id, 'stream ids from srcObjects match');
+    t.ok(video.srcObject.id === video2.srcObject.id,
+        'stream ids from srcObjects match');
     t.end();
   })
   .catch(function(err) {
@@ -225,7 +226,7 @@ test('reattaching mediaStream directly', function(t) {
   video2.onloadedmetadata = function() {
     t.pass('got stream on second video with w=' + video.videoWidth +
            ',h=' + video.videoHeight);
-  }
+  };
 
   var constraints = {video: true, fake: true};
   navigator.mediaDevices.getUserMedia(constraints)


### PR DESCRIPTION
@alvestrand -- you mentioned "experiment with setting src on video" a while back.
I'm not sure how I found https://developers.google.com/web/updates/2015/04/DOM-attributes-now-on-the-prototype but it was incredibly helpful...

@jan-ivar take your time with renaming mozSrcObject :-)

This isn't done yet. Most importantly, reattachMediaStream in Chrome is incomplete yet. I think that setting srcObject should set a googSrcObject (?) property which the get accessor can return.

Also, should we remove attachMediaStream and reattachMediaStream and bump the major version? Probably some other cleanup to do if we break backward compat anyway...

This probably also requires Chrome 43+, probably Paul Kinlan can confirm. Heck, this "move stuff to the prototype chain" in 43 has had positive effects!

samples-tests still pass, merge with confidence
