### PR TITLE
remove grunt githooks from postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "url": "https://github.com/webrtc/adapter.git"
   },
   "scripts": {
-    "postinstall": "grunt githooks",
     "test": "test/run-tests"
   },
   "testling": {


### PR DESCRIPTION
Removing postinstall githooks as it prevents adapter from being installed properly.
