### PR TITLE
Add editorconfig for helping enforce code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js, json}]
+charset = utf-8
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
I find myself having to change my editor settings from 4 to 2 spaces - having an editorconfig in the project makes this happen automatically.
