### PR TITLE
shim srcObject and set export defaults

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,25 @@ test('video srcObject getter/setter test', function(t) {
   });
 });
 
+test('audio srcObject getter/setter test', function(t) {
+  t.plan(3);
+  var audio = document.createElement('audio');
+
+  var constraints = {video: false, audio: true, fake: true};
+  navigator.mediaDevices.getUserMedia(constraints)
+  .then(function(stream) {
+    t.pass('got stream');
+    audio.srcObject = stream;
+    t.pass('srcObject set');
+    t.ok(audio.srcObject.id === stream.id,
+        'srcObject getter returns stream object');
+    stream.getTracks().forEach(function(track) { track.stop(); });
+  })
+  .catch(function(err) {
+    t.fail(err.toString());
+  });
+});
+
 test('srcObject set from another object', function(t) {
   var video = document.createElement('video');
   var video2 = document.createElement('video');


### PR DESCRIPTION
This PR provides a similar shim from #119, Except that the property detection will not return the non-prefixed value incorrectly, when the prefixed value is falsy.

Its main purpose though is to initialize the exports (getUserMedia, attachMediaStream, reattachMediaStream) so that a browser that doesn't need "detection" (one that supports spec or has been shimmed to do so prior to running adapter.js) can still have those exports provided. (imho the adapter shouldn't take the responsibility of providing detected browser to its dependents)

It also addresses chromium "detection" which fixes issues in #71 (removes the need to detect a plugin that registers globally available spec compliant methods) and should fix #94 (can't confirm).
