### PR TITLE
Bump to version 0.2.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-adapter",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "A shim to insulate apps from WebRTC spec changes and prefix differences",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-adapter-test",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Hide browser differences in WebRTC APIs (test package name)",
   "license": "BSD-3-Clause",
   "main": "adapter.js",


### PR DESCRIPTION
Since I was a bit fast on creating the github release before updating bower.json and package.json, I have to skip 0.2.2.
