### PR TITLE
make versioncheck more robust

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -233,12 +233,10 @@ if (typeof window === 'undefined' || !window.navigator) {
   webrtcDetectedBrowser = 'chrome';
 
   // the detected chrome version.
-  webrtcDetectedVersion = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
-  if (webrtcDetectedVersion && webrtcDetectedVersion.length >= 2) {
-    webrtcDetectedVersion = parseInt(webrtcDetectedVersion[2], 10);
-  } else {
-    webrtcDetectedVersion = 0;
-  }
+  webrtcDetectedVersion = (function() {
+    var match = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    return match.length >= 2 && parseInt(match[2]);
+  })();
 
   // the minimum chrome version still supported by adapter.
   webrtcMinimumVersion = 38;

--- a/adapter.js
+++ b/adapter.js
@@ -227,14 +227,18 @@ if (typeof window === 'undefined' || !window.navigator) {
       });
     };
   }
-} else if (navigator.webkitGetUserMedia && !!window.chrome) {
+} else if (navigator.webkitGetUserMedia && window.webkitRTCPeerConnection) {
   webrtcUtils.log('This appears to be Chrome');
 
   webrtcDetectedBrowser = 'chrome';
 
   // the detected chrome version.
-  webrtcDetectedVersion =
-    parseInt(navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./)[2], 10);
+  webrtcDetectedVersion = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+  if (webrtcDetectedVersion && webrtcDetectedVersion.length >= 2) {
+    webrtcDetectedVersion = parseInt(webrtcDetectedVersion[2], 10);
+  } else {
+    webrtcDetectedVersion = 0;
+  }
 
   // the minimum chrome version still supported by adapter.
   webrtcMinimumVersion = 38;

--- a/adapter.js
+++ b/adapter.js
@@ -30,6 +30,10 @@ var webrtcUtils = {
       return;
     }
     console.log.apply(console, arguments);
+  },
+  extractVersion: function(uastring, expr, pos) {
+    var match = uastring.match(expr);
+    return match && match.length >= pos && parseInt(match[pos]);
   }
 };
 
@@ -90,8 +94,8 @@ if (typeof window === 'undefined' || !window.navigator) {
   webrtcDetectedBrowser = 'firefox';
 
   // the detected firefox version.
-  webrtcDetectedVersion =
-    parseInt(navigator.userAgent.match(/Firefox\/([0-9]+)\./)[1], 10);
+  webrtcDetectedVersion = webrtcUtils.extractVersion(navigator.userAgent,
+      /Firefox\/([0-9]+)\./, 1);
 
   // the minimum firefox version still supported by adapter.
   webrtcMinimumVersion = 31;
@@ -233,10 +237,8 @@ if (typeof window === 'undefined' || !window.navigator) {
   webrtcDetectedBrowser = 'chrome';
 
   // the detected chrome version.
-  webrtcDetectedVersion = (function() {
-    var match = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
-    return match.length >= 2 && parseInt(match[2]);
-  })();
+  webrtcDetectedVersion = webrtcUtils.extractVersion(navigator.userAgent,
+      /Chrom(e|ium)\/([0-9]+)\./, 2);
 
   // the minimum chrome version still supported by adapter.
   webrtcMinimumVersion = 38;
@@ -483,8 +485,8 @@ if (typeof window === 'undefined' || !window.navigator) {
   webrtcUtils.log('This appears to be Edge');
   webrtcDetectedBrowser = 'edge';
 
-  webrtcDetectedVersion =
-    parseInt(navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)[2], 10);
+  webrtcDetectedVersion = webrtcUtils.extractVersion(navigator.userAgent,
+      /Edge\/(\d+).(\d+)$/, 2);
 
   // the minimum version still supported by adapter.
   webrtcMinimumVersion = 12;
@@ -521,7 +523,8 @@ if (typeof module !== 'undefined') {
     webrtcDetectedBrowser: webrtcDetectedBrowser,
     webrtcDetectedVersion: webrtcDetectedVersion,
     webrtcMinimumVersion: webrtcMinimumVersion,
-    webrtcTesting: webrtcTesting
+    webrtcTesting: webrtcTesting,
+    webrtcUtils: webrtcUtils
     //requestUserMedia: not exposed on purpose.
     //trace: not exposed on purpose.
   };
@@ -536,7 +539,8 @@ if (typeof module !== 'undefined') {
       webrtcDetectedBrowser: webrtcDetectedBrowser,
       webrtcDetectedVersion: webrtcDetectedVersion,
       webrtcMinimumVersion: webrtcMinimumVersion,
-      webrtcTesting: webrtcTesting
+      webrtcTesting: webrtcTesting,
+      webrtcUtils: webrtcUtils
       //requestUserMedia: not exposed on purpose.
       //trace: not exposed on purpose.
     };

--- a/test/test.js
+++ b/test/test.js
@@ -59,6 +59,57 @@ test('Browser supported by adapter.js', function(t) {
       'Browser version supported by adapter.js');
 });
 
+// Fiddle with the UA string to test the extraction does not throw errors.
+test('Browser version extraction helper', function(t) {
+  // Chrome and Chromium.
+  var ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+      'Gecko) Chrome/45.0.2454.101 Safari/537.36';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+      'version extraction');
+
+  ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+      'Gecko) Ubuntu Chromium/45.0.2454.85 Chrome/45.0.2454.85 Safari/537.36';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+      'version extraction');
+
+  // Various UA strings from device simulator, not matching.
+  ua = 'Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) ' +
+      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2307.2 Safari/537.36';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 42,
+      'version extraction');
+
+  ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
+      'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d ' +
+      'Safari/600.1.4';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === null,
+      'version extraction');
+
+  ua = 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19' +
+      '(KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === null,
+      'version extraction');
+
+  // Opera, should match chrome/webrtc version 45.0 not Opera 32.0.
+  ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like ' +
+      'Gecko) Chrome/45.0.2454.85 Safari/537.36 OPR/32.0.1948.44';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+      'version extraction');
+
+  // Edge, extract build number.
+  ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ' +
+      'like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Edge\/(\d+).(\d+)$/, 2) === 10547,
+      'version extraction');
+
+  // Firefox.
+  ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
+      'Firefox/44.0';
+  t.ok(m.webrtcUtils.extractVersion(ua, /Firefox\/([0-9]+)\./, 1) === 44,
+      'version extraction');
+
+  t.end();
+});
+
 test('getUserMedia shim', function(t) {
   t.ok(typeof navigator.getUserMedia !== 'undefined',
        'navigator.getUserMedia is defined');

--- a/test/test.js
+++ b/test/test.js
@@ -64,47 +64,47 @@ test('Browser version extraction helper', function(t) {
   // Chrome and Chromium.
   var ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
       'Gecko) Chrome/45.0.2454.101 Safari/537.36';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
       'version extraction');
 
   ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
       'Gecko) Ubuntu Chromium/45.0.2454.85 Chrome/45.0.2454.85 Safari/537.36';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
       'version extraction');
 
   // Various UA strings from device simulator, not matching.
   ua = 'Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) ' +
       'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2307.2 Safari/537.36';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 42,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 42,
       'version extraction');
 
   ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
       'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d ' +
       'Safari/600.1.4';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === null,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), null,
       'version extraction');
 
   ua = 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19' +
       '(KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === null,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), null,
       'version extraction');
 
   // Opera, should match chrome/webrtc version 45.0 not Opera 32.0.
   ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like ' +
       'Gecko) Chrome/45.0.2454.85 Safari/537.36 OPR/32.0.1948.44';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2) === 45,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
       'version extraction');
 
   // Edge, extract build number.
   ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ' +
       'like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Edge\/(\d+).(\d+)$/, 2) === 10547,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Edge\/(\d+).(\d+)$/, 2), 10547,
       'version extraction');
 
   // Firefox.
   ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
       'Firefox/44.0';
-  t.ok(m.webrtcUtils.extractVersion(ua, /Firefox\/([0-9]+)\./, 1) === 44,
+  t.equal(m.webrtcUtils.extractVersion(ua, /Firefox\/([0-9]+)\./, 1), 44,
       'version extraction');
 
   t.end();


### PR DESCRIPTION
This fixes #132 and #122
@tednakamura can you check http://hancke.name/tmp/opr.html shows a version instead of a blank page in webview? (it would then fix #135)

Not sure what the unsupported version should be... set it to 0.
