### PR TITLE
Expose RTCIceCandidate and RTCSessionDescription

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -517,6 +517,8 @@ if (typeof module !== 'undefined') {
   }
   module.exports = {
     RTCPeerConnection: RTCPeerConnection,
+    RTCIceCandidate: RTCIceCandidate,
+    RTCSessionDescription: RTCSessionDescription,
     getUserMedia: getUserMedia,
     attachMediaStream: attachMediaStream,
     reattachMediaStream: reattachMediaStream,
@@ -533,6 +535,8 @@ if (typeof module !== 'undefined') {
   define([], function() {
     return {
       RTCPeerConnection: window.RTCPeerConnection,
+      RTCIceCandidate: RTCIceCandidate,
+      RTCSessionDescription: RTCSessionDescription,
       getUserMedia: getUserMedia,
       attachMediaStream: attachMediaStream,
       reattachMediaStream: reattachMediaStream,

--- a/adapter.js
+++ b/adapter.js
@@ -511,7 +511,9 @@ try {
 } catch (e) {}
 
 if (typeof module !== 'undefined') {
-  var RTCPeerConnection, RTCIceCandidate, RTCSessionDescription;
+  var RTCPeerConnection;
+  var RTCIceCandidate;
+  var RTCSessionDescription;
   if (typeof window !== 'undefined') {
     RTCPeerConnection = window.RTCPeerConnection;
     RTCIceCandidate = window.RTCIceCandidate;

--- a/adapter.js
+++ b/adapter.js
@@ -511,9 +511,11 @@ try {
 } catch (e) {}
 
 if (typeof module !== 'undefined') {
-  var RTCPeerConnection;
+  var RTCPeerConnection, RTCIceCandidate, RTCSessionDescription;
   if (typeof window !== 'undefined') {
     RTCPeerConnection = window.RTCPeerConnection;
+    RTCIceCandidate = window.RTCIceCandidate;
+    RTCSessionDescription = window.RTCSessionDescription;
   }
   module.exports = {
     RTCPeerConnection: RTCPeerConnection,
@@ -535,8 +537,8 @@ if (typeof module !== 'undefined') {
   define([], function() {
     return {
       RTCPeerConnection: window.RTCPeerConnection,
-      RTCIceCandidate: RTCIceCandidate,
-      RTCSessionDescription: RTCSessionDescription,
+      RTCIceCandidate: window.RTCIceCandidate,
+      RTCSessionDescription: window.RTCSessionDescription,
       getUserMedia: getUserMedia,
       attachMediaStream: attachMediaStream,
       reattachMediaStream: reattachMediaStream,


### PR DESCRIPTION
Very minor change mirroring the API of projects like [js-platform/node-webrtc](https://github.com/js-platform/node-webrtc), which explicity expose the above functions.

This change is very useful for developers targeting both client- and server-side deployment - presently the API forces users to check from their own modules whether or not ICE candidates and session descriptions are globally defined. 
