### PR TITLE
Add browser version check in the webdriver creation step

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014 The WebRTC project authors. All Rights Reserved.
+ *  Copyright (c) 2015 The WebRTC project authors. All Rights Reserved.
  *
  *  Use of this source code is governed by a BSD-style license
  *  that can be found in the LICENSE file in the root of the source

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -74,7 +74,7 @@ function buildDriver() {
       .addArguments('use-fake-ui-for-media-stream');
 
   // Only enable this for Chrome >= 49.
-  if (getBrowserVersion >= '49') {
+  if (process.env.BROWSER === 'chrome' && getBrowserVersion >= '49') {
     chromeOptions.addArguments('--enable-experimental-web-platform-features');
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -383,7 +383,7 @@ test('attachMediaStream', function(t) {
       webdriver.By.id('video')), 3000);
   })
   .then(function(videoElement) {
-    t.pass('attachMediaStream succesfully attached stream to video element');
+    t.pass('attachMediaStream successfully attached stream to video element');
     videoElement.getAttribute('videoWidth')
     .then(function(width) {
       videoElement.getAttribute('videoHeight')
@@ -468,7 +468,7 @@ test('reattachMediaStream', function(t) {
       webdriver.By.id('video')), 3000);
   })
   .then(function(videoElement) {
-    t.pass('attachMediaStream succesfully attached stream to video element');
+    t.pass('attachMediaStream successfully attached stream to video element');
     videoElement.getAttribute('videoWidth')
     .then(function(width) {
       videoElement.getAttribute('videoHeight')


### PR DESCRIPTION
This allows to set browser command line flags conditionally based on the browser version. This should address the concern in https://github.com/webrtc/adapter/pull/158#issuecomment-165861005.

I will fix the flaky video tag issue in another PR.
