### PR TITLE
Use explicit reference to window.RTCPeerConnection for require context

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -134,7 +134,7 @@ if (typeof window === 'undefined' || !window.navigator) {
 
   // wrap static methods. Currently just generateCertificate.
   if (mozRTCPeerConnection.generateCertificate) {
-    Object.defineProperty(RTCPeerConnection, 'generateCertificate', {
+    Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
       get: function() {
         if (arguments.length) {
           return mozRTCPeerConnection.generateCertificate.apply(null,
@@ -323,7 +323,7 @@ if (typeof window === 'undefined' || !window.navigator) {
 
   // wrap static methods. Currently just generateCertificate.
   if (webkitRTCPeerConnection.generateCertificate) {
-    Object.defineProperty(RTCPeerConnection, 'generateCertificate', {
+    Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
       get: function() {
         if (arguments.length) {
           return webkitRTCPeerConnection.generateCertificate.apply(null,


### PR DESCRIPTION
This fixes an error occurring in a require context: `"Object.defineProperty called on non-object"`. When used in a require context, I'm getting `RTCPeerConnection` as undefined here, since `this` is not `window`. Since Adapter explicitly is explicitly adding `RTCPeerConnection` to the window, use that object explicitly.
