### PR TITLE
deal with string gum constraints

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -383,8 +383,8 @@ if (typeof window === 'undefined' || !window.navigator) {
         return;
       }
       var r = (typeof c[key] === 'object') ? c[key] : {ideal: c[key]};
-      if (r.exact !== undefined && typeof r.exact === 'number') {
-        r.min = r.max = r.exact;
+      if (r.exact !== undefined) {
+        r.min = r.max = r.exact = parseInt(r.exact, 10);
       }
       var oldname = function(prefix, name) {
         if (prefix) {


### PR DESCRIPTION
```
var vgaConstraints = {
  video: {width: {exact: "640"}, height: {exact: "480"}}
};

navigator.mediaDevices.getUserMedia(vgaConstraints).then(function(stream) { console.log('yay'); }).catch(function(err) { console.log(err); })
```

Both Firefox and Edge deal with this, but the shim does not. I think this should cover the relevant cases. wdyt @jan-ivar?
