### PR TITLE
shim addTrack

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -1701,7 +1701,7 @@ if (typeof window === 'object' && window.RTCPeerConnection && !('ontrack' in
       this.addEventListener('addstream', this._ontrackpoly = function(e) {
         if (webrtcDetectedBrowser === 'chrome') {
           // onaddstream does not fire when a track is added to an existing stream.
-          // but stream.onaddtrack is implemented so we use thたt
+          // but stream.onaddtrack is implemented so we use that
           e.stream.addEventListener('addtrack', function(te) {
             var event = new Event('track');
             event.track = te.track;

--- a/adapter.js
+++ b/adapter.js
@@ -1724,7 +1724,7 @@ if (typeof window === 'object' && window.RTCPeerConnection && !('ontrack' in
 
 if (typeof window === 'object' && window.RTCPeerConnection && !('addTrack' in
     window.RTCPeerConnection.prototype)) {
-  RTCPeerConnection.prototype.addTrack = function(track, stream) {
+  window.RTCPeerConnection.prototype.addTrack = function(track, stream) {
     var streams = this.getLocalStreams();
     if (streams.indexOf(stream) !== -1) {
       streams[streams.indexOf(stream)].addTrack(track);


### PR DESCRIPTION
Note that I can't return an RTPSender.

also this recreates the blob url whenever a track is added to a stream attached to a video element.
This causes a slight visual glitch but... we might have native srcObject soon.

Should that also remove the event listeners when the srcObject is changed?
