### PR TITLE
no dep on grunt, set main to adapter_core.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
-  "main": "out/adapter.js",
+  "main": "./src/js/adapter_core.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
@@ -16,9 +16,6 @@
     "test": "grunt && test/run-tests"
   },
   "dependencies": {
-    "grunt": "^0.4.5",
-    "grunt-browserify": "^4.0.1",
-    "grunt-cli": ">=0.1.9"
   },
   "devDependencies": {
     "chromedriver": "^2.16.0",


### PR DESCRIPTION
I missed that before... need more :eyes:
I think main should not point to the generated out.js -- and then we don't need grunt as dep, only as dev-dependency.

I also think we don't need to use the module pattern in adapter_core.js but that is a style nit :-)
