### PR TITLE
reset blob url on track addition

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -59,6 +59,13 @@ var chromeShim = {
             this._srcObject = stream;
             // TODO: revokeObjectUrl(this.src) when !stream to release resources?
             this.src = URL.createObjectURL(stream);
+            // We need to recreate the blob url when a track is added or removed
+            stream.addEventListener('addtrack', function() {
+              self.src = URL.createObjectURL(stream);
+            });
+            stream.addEventListener('removetrack', function() {
+              self.src = URL.createObjectURL(stream);
+            });
           }
         });
       }

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -57,13 +57,22 @@ var chromeShim = {
           set: function(stream) {
             // Use _srcObject as a private property for this shim
             this._srcObject = stream;
-            // TODO: revokeObjectUrl(this.src) when !stream to release resources?
+            if (this.src) {
+              URL.revokeObjectURL(this.src);
+            }
             this.src = URL.createObjectURL(stream);
-            // We need to recreate the blob url when a track is added or removed
+            // We need to recreate the blob url when a track is added or removed.
+            // Doing it manually since we want to avoid a recursion.
             stream.addEventListener('addtrack', function() {
+              if (self.src) {
+                URL.revokeObjectURL(self.src);
+              }
               self.src = URL.createObjectURL(stream);
             });
             stream.addEventListener('removetrack', function() {
+              if (self.src) {
+                URL.revokeObjectURL(self.src);
+              }
               self.src = URL.createObjectURL(stream);
             });
           }


### PR DESCRIPTION
one thing I originally wanted in #182
basically that is required to show video in a scenario like audio->audio/video

Do we want a test for this? I think I can use https://github.com/webrtc/testrtc/blob/master/src/js/camresolutionstest.js#L353-L361 to assert video is shown but that would need an update of the utils first.
