### PR TITLE
Fix bower version, main path and moduleType

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
   "name": "webrtc-adapter",
-  "version": "0.3.0",
+  "version": "1.0.2",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
-  "main": "out/adapter.js",
+  "main": "./src/js/adapter-core.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
@@ -12,7 +12,7 @@
     "The WebRTC project authors (https://www.webrtc.org/)"
   ],
   "moduleType": [
-    "globals"
+    "node"
   ],
   "ignore": [
     "test/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webrtc-adapter",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
   "main": "./src/js/adapter_core.js",


### PR DESCRIPTION
**Description**
Bower version, main path and moduleType were all wrong

**Purpose**
According to https://github.com/bower/spec/blob/master/json.md the main file should a source file with module exports.
