### PR TITLE
Update utils.js

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -87,6 +87,10 @@ var utils = {
       result.minVersion = 10547;
       return result;
     }
+    
+    // Non supported browser default.
+    result.browser = 'Not a supported browser.';
+    return result;
   }
 };
 


### PR DESCRIPTION
adapter_core.js was throwing an error on my iPhone6 because none of the if statements in detectBrowser were resolving. Maybe there's a more elegant way of handling iOS, but in general, I think it would be best to have a default at the end of the detectBrowser function so it at least returns and doesn't throw errors
