### PR TITLE
Added missing semicolon on utils.js

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -51,7 +51,7 @@ var utils = {
     // Returned result object.
     var result = {};
     result.browser = null;
-    result.version = null
+    result.version = null;
     result.minVersion = null;
 
     // Non supported browser.


### PR DESCRIPTION
**Description**

Added missing semicolon on utils.js

**Purpose**

Some ancient browsers (like IE 8) Cannot handle correctly the fact that a semicolon is missing at the end of the line.
With this modification the code will run smooth on IE 8.
