### PR TITLE
fix for webpack require shim

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -39,7 +39,7 @@
   // Shim browser if found.
   switch (browserDetails.browser) {
     case 'chrome':
-      if (!chromeShim) {
+      if (!chromeShim||!chromeShim.shimPeerConnection) {
         logging('Chrome shim is not included in this adapter release.');
         return;
       }
@@ -53,7 +53,7 @@
       chromeShim.shimOnTrack();
       break;
     case 'edge':
-      if (!edgeShim) {
+      if (!edgeShim||!edgeShim.shimPeerConnection) {
         logging('MS edge shim is not included in this adapter release.');
         return;
       }
@@ -64,7 +64,7 @@
       edgeShim.shimPeerConnection();
       break;
     case 'firefox':
-    if (!firefoxShim) {
+      if (!firefoxShim||!firefoxShim.shimPeerConnection) {
         logging('Firefox shim is not included in this adapter release.');
         return;
       }


### PR DESCRIPTION
**Description**
Add additional checks for no_edge version

**Purpose**
Fix error in no_edge version with build with webpack.  
var edgeShim = require('./edge/edge_shim') || null;
edgeShim will be {} and !edgeShim==true
and broke this check
 if (!edgeShim) {
  logging('MS edge shim is not included in this adapter release.');
  return;
}
