### PR TITLE
Edge: update localdescription and remotedescription with ice candidates

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -309,7 +309,10 @@ var edgeShim = {
         });
       }
 
-      this.localDescription = description;
+      this.localDescription = {
+        type: description.type,
+        sdp: description.sdp
+      };
       switch (description.type) {
         case 'offer':
           this._updateSignalingState('have-local-offer');
@@ -461,7 +464,10 @@ var edgeShim = {
         }
       });
 
-      this.remoteDescription = description;
+      this.remoteDescription = {
+          type: description.type,
+          sdp: description.sdp
+      };
       switch (description.type) {
         case 'offer':
           this._updateSignalingState('have-remote-offer');

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -749,6 +749,12 @@ var edgeShim = {
           cand = {};
         }
         transceiver.iceTransport.addRemoteCandidate(cand);
+
+        // update the remoteDescription.
+        var sections = SDPUtils.splitSections(this.remoteDescription.sdp);
+        sections[mLineIndex + 1] += cand.type ? candidate.candidate + '\r\n' :
+            'a=end-of-candidates\r\n';
+        this.remoteDescription.sdp = sections.join('');
       }
       if (arguments.length > 1 && typeof arguments[1] === 'function') {
         window.setTimeout(arguments[1], 0);


### PR DESCRIPTION
**Description**
this updates the local/remote description when ice candidates are emitted

**Purpose**
enabling non-trickle ice is the main use-case

**version considerations**
Not urgent, but should be a minor version. Together with #217 
