### PR TITLE
fix most jshint/jscs style nits

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -39,7 +39,7 @@
   // Shim browser if found.
   switch (browserDetails.browser) {
     case 'chrome':
-      if (!chromeShim||!chromeShim.shimPeerConnection) {
+      if (!chromeShim || !chromeShim.shimPeerConnection) {
         logging('Chrome shim is not included in this adapter release.');
         return;
       }
@@ -53,7 +53,7 @@
       chromeShim.shimOnTrack();
       break;
     case 'edge':
-      if (!edgeShim||!edgeShim.shimPeerConnection) {
+      if (!edgeShim || !edgeShim.shimPeerConnection) {
         logging('MS edge shim is not included in this adapter release.');
         return;
       }
@@ -64,7 +64,7 @@
       edgeShim.shimPeerConnection();
       break;
     case 'firefox':
-      if (!firefoxShim||!firefoxShim.shimPeerConnection) {
+      if (!firefoxShim || !firefoxShim.shimPeerConnection) {
         logging('Firefox shim is not included in this adapter release.');
         return;
       }

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -55,6 +55,7 @@ var chromeShim = {
             return this._srcObject;
           },
           set: function(stream) {
+            var self = this;
             // Use _srcObject as a private property for this shim
             this._srcObject = stream;
             if (this.src) {
@@ -126,7 +127,8 @@ var chromeShim = {
             args[1](fixChromeStats_(response));
           };
 
-          return origGetStats.apply(this, [successCallbackWrapper_, arguments[0]]);
+          return origGetStats.apply(this, [successCallbackWrapper_,
+              arguments[0]]);
         }
 
         // promise-support
@@ -272,7 +274,7 @@ var chromeShim = {
       return new Promise(function(resolve, reject) {
         navigator.getUserMedia(constraints, resolve, reject);
       });
-    }
+    };
 
     if (!navigator.mediaDevices) {
       navigator.mediaDevices = {getUserMedia: getUserMediaPromise_,
@@ -348,7 +350,7 @@ var chromeShim = {
       to.src = from.src;
     }
   }
-}
+};
 
 // Expose public methods.
 module.exports = {

--- a/src/js/edge/edge_sdp.js
+++ b/src/js/edge/edge_sdp.js
@@ -19,7 +19,6 @@ SDPUtils.generateIdentifier = function() {
 // The RTCP CNAME used by all peerconnections from the same JS.
 SDPUtils.localCName = SDPUtils.generateIdentifier();
 
-
 // Splits SDP into lines, dealing with both CRLF and LF.
 SDPUtils.splitLines = function(blob) {
   return blob.trim().split('\n').map(function(line) {

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -9,7 +9,6 @@
 
 var SDPUtils = require('./edge_sdp');
 var logging = require('../utils').log;
-var browserDetails = require('../utils').browserDetails;
 
 var edgeShim = {
   shimPeerConnection: function() {
@@ -833,12 +832,11 @@ var edgeShim = {
     logging('DEPRECATED, reattachMediaStream will soon be removed.');
     to.srcObject = from.srcObject;
   }
-}
+};
 
 // Expose public methods.
 module.exports = {
   shimPeerConnection: edgeShim.shimPeerConnection,
   attachMediaStream: edgeShim.attachMediaStream,
   reattachMediaStream: edgeShim.reattachMediaStream
-}
-
+};

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -17,7 +17,6 @@ var firefoxShim = {
       Object.defineProperty(window.RTCPeerConnection.prototype, 'ontrack', {
         get: function() { return this._ontrack; },
         set: function(f) {
-          var self = this;
           if (this._ontrack) {
             this.removeEventListener('track', this._ontrack);
             this.removeEventListener('addstream', this._ontrackpoly);
@@ -116,7 +115,8 @@ var firefoxShim = {
         }
         var require = [];
         Object.keys(c).forEach(function(key) {
-          if (key === 'require' || key === 'advanced' || key === 'mediaSource') {
+          if (key === 'require' || key === 'advanced' ||
+              key === 'mediaSource') {
             return;
           }
           var r = c[key] = (typeof c[key] === 'object') ?
@@ -173,7 +173,7 @@ var firefoxShim = {
       return new Promise(function(resolve, reject) {
         navigator.getUserMedia(constraints, resolve, reject);
       });
-    }
+    };
 
     // Shim for mediaDevices on older versions.
     if (!navigator.mediaDevices) {
@@ -218,7 +218,7 @@ var firefoxShim = {
     logging('DEPRECATED, reattachMediaStream will soon be removed.');
     to.srcObject = from.srcObject;
   }
-}
+};
 
 // Expose public methods.
 module.exports = {
@@ -228,4 +228,4 @@ module.exports = {
   shimGetUserMedia: firefoxShim.shimGetUserMedia,
   attachMediaStream: firefoxShim.attachMediaStream,
   reattachMediaStream: firefoxShim.reattachMediaStream
-}
+};

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -30,8 +30,9 @@ var utils = {
     }
   },
 
-   /**
+  /**
    * Extract browser version out of the provided user agent string.
+   *
    * @param {!string} uastring userAgent string.
    * @param {!string} expr Regular expression used as match criteria.
    * @param {!number} pos position in the version string to be returned.
@@ -44,6 +45,7 @@ var utils = {
 
   /**
    * Browser detector.
+   *
    * @return {object} result containing browser, version and minVersion
    *     properties.
    */
@@ -87,7 +89,7 @@ var utils = {
       result.minVersion = 10547;
       return result;
     }
-    
+
     // Non supported browser default.
     result.browser = 'Not a supported browser.';
     return result;


### PR DESCRIPTION
**Description**
fixes most style nits reported by jshint and jscs after I re-added those files to linting.
We currently only list adapter_core.js (doesn't exist) and test/_.js -- but we need to lint test/_.js and src/js/**/.js
The other stuff is probably best left until we move to eslint.

Linting also exposed a missing 'var self = this;' in the chrome srcObject shim. Boo.
