### PR TITLE
set src to empty string when setting null srcobject

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -55,10 +55,16 @@ var chromeShim = {
             return this._srcObject;
           },
           set: function(stream) {
+            var self = this;
             // Use _srcObject as a private property for this shim
             this._srcObject = stream;
             if (this.src) {
               URL.revokeObjectURL(this.src);
+            }
+
+            if (!stream) {
+              this.src = '';
+              return;
             }
             this.src = URL.createObjectURL(stream);
             // We need to recreate the blob url when a track is added or removed.

--- a/test/test.js
+++ b/test/test.js
@@ -348,10 +348,10 @@ test('attachMediaStream', function(t) {
       // due to 38 being stable now.
       video.addEventListener('resize', function() {
         document.body.appendChild(video);
+        callback(null);
       });
 
       window.adapter.browserShim.attachMediaStream(video, stream);
-      callback(null);
     })
     .catch(function(err) {
       callback(err.name);
@@ -436,10 +436,10 @@ test('reattachMediaStream', function(t) {
       });
       video2.addEventListener('resize', function() {
         document.body.appendChild(video2);
+        callback(null);
       });
 
       window.adapter.browserShim.attachMediaStream(video, stream);
-      callback(null);
     })
     .catch(function(err) {
       callback(err.name);
@@ -531,8 +531,8 @@ test('Video srcObject getter/setter test', function(t) {
       // at some point. This will trigger onresize.
       video.addEventListener('resize', function() {
         document.body.appendChild(video);
+        callback(null);
       });
-      callback(null);
     })
     .catch(function(err) {
       callback(err.name);
@@ -597,8 +597,8 @@ test('Audio srcObject getter/setter test', function(t) {
       // at some point. This will trigger onresize.
       audio.addEventListener('loadedmetadata', function() {
         document.body.appendChild(audio);
+        callback(null);
       });
-      callback(null);
     })
     .catch(function(err) {
       callback(err.name);
@@ -668,8 +668,8 @@ test('srcObject set from another object', function(t) {
       video.addEventListener('resize', function() {
         document.body.appendChild(video);
         document.body.appendChild(video2);
+        callback(null);
       });
-      callback(null);
     })
     .catch(function(err) {
       callback(err.name);

--- a/test/test.js
+++ b/test/test.js
@@ -760,8 +760,8 @@ test('srcObject null setter', function(t) {
         'return document.getElementById(\'video\').src');
   })
   .then(function(src) {
-    t.ok(src === 'file://' + process.cwd() + '/test/testpage.html',
-        'src is the empty string'); // kind of... it actually is this page.
+    t.ok(src === 'file://' + process.cwd() + '/test/testpage.html' ||
+        src === '', 'src is the empty string'); // kind of... it actually is this page.
   })
   .then(function() {
     t.end();


### PR DESCRIPTION
**Description**
sets src to the empty string when setting the srcObject to null. Also bails out earlier and doesn't try to add event listeners.

**Purpose**
fixes #224 
