### PR TITLE
fix broken candidate sdp

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -118,7 +118,7 @@ var edgeShim = {
           }
         } else {
           sections[event.candidate.sdpMLineIndex + 1] +=
-              event.candidate.candidate + '\r\n';
+              'a=' + event.candidate.candidate + '\r\n';
         }
         self.dispatchEvent(event);
         if (self.onicecandidate !== null) {
@@ -226,7 +226,7 @@ var edgeShim = {
         //     Edge 10547 when no candidates have been gathered yet.
         if (self.localDescription && self.localDescription.type !== '') {
           var sections = SDPUtils.splitSections(self.localDescription.sdp);
-          sections[sdpMLineIndex + 1] += (!end ? event.candidate.candidate :
+          sections[sdpMLineIndex + 1] += (!end ? 'a=' + event.candidate.candidate :
               'a=end-of-candidates') + '\r\n';
           self.localDescription.sdp = sections.join('');
         }


### PR DESCRIPTION
**Description**
I added candidates to the sdp without thinking that candidates are defined without the a= in the ice candidate event...

I think i need some edge-specific tests for all the SDP behaviour :-(
