### PR TITLE
Enable fixChromeStats_() if window.RTCPeerConnection.getStats() used …

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -138,7 +138,7 @@ var chromeShim = {
 
         // promise-support
         return new Promise(function(resolve, reject) {
-          if (args.length === 1 && selector === null) {
+          if (args.length === 1 && selector === 'object') {
             origGetStats.apply(self, [
                 function(response) {
                   resolve.apply(null, [fixChromeStats_(response)]);

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -138,7 +138,7 @@ var chromeShim = {
 
         // promise-support
         return new Promise(function(resolve, reject) {
-          if (args.length === 1 && selector === 'object') {
+          if (args.length === 1 && typeof selector === 'object') {
             origGetStats.apply(self, [
                 function(response) {
                   resolve.apply(null, [fixChromeStats_(response)]);


### PR DESCRIPTION
**Description**
Enable fixChromeStats_() if window.RTCPeerConnection.getStats() used with a selector is passed in. This only partially fixes the stats compat issues but is a first step.

https://github.com/webrtc/adapter/issues/243
