### PR TITLE
Removed unnecessary comma

### DIFF
--- a/src/js/edge/edge_sdp.js
+++ b/src/js/edge/edge_sdp.js
@@ -195,7 +195,7 @@ SDPUtils.writeRtcpFb = function(codec) {
 SDPUtils.parseSsrcMedia = function(line) {
   var sp = line.indexOf(' ');
   var parts = {
-    ssrc: line.substr(7, sp - 7),
+    ssrc: line.substr(7, sp - 7)
   };
   var colon = line.indexOf(':', sp);
   if (colon > -1) {


### PR DESCRIPTION
**Description**

With this modification the file is parsed correctly by IE

**Purpose**

Some browsers like IE does not like the unnecessary commas and fail to parse the script.
