### PR TITLE
Conditionally do 'console.log' call

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -26,7 +26,9 @@ var utils = {
       if (logDisabled_) {
         return;
       }
-      console.log.apply(console, arguments);
+      if (typeof console !== 'undefined' && typeof console.log === 'function') {
+        console.log.apply(console, arguments);
+      }
     }
   },
 


### PR DESCRIPTION
**Description**

Verify the presence of the console.log function before to call it.

**Purpose**

Some browsers fail on console object
