### PR TITLE
make ontrack pass again

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2197,6 +2197,7 @@ test('ontrack', function(t) {
   .then(function(pc1ConnectionStatus) {
     t.ok(pc1ConnectionStatus === 'completed' || 'connected',
       'P2P connection established');
+    driver.sleep(1000); // flaky in firefox
     return driver.executeScript('return window.testPassed');
   })
   .then(function(testPassed) {


### PR DESCRIPTION
ontrack seems flaky. It seems that ice connection state can go to connected or completed before ontrack fires. Which is really, really odd. @jan-ivar you might want to take a look.

This adds a one-second sleep which seems sufficient to fix that.
