### PR TITLE
remove unnecessary code in generateCertificate wrapper

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -160,10 +160,6 @@ var chromeShim = {
     if (webkitRTCPeerConnection.generateCertificate) {
       Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
         get: function() {
-          if (arguments.length) {
-            return webkitRTCPeerConnection.generateCertificate.apply(null,
-                arguments);
-          }
           return webkitRTCPeerConnection.generateCertificate;
         }
       });

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -94,10 +94,6 @@ var firefoxShim = {
       if (mozRTCPeerConnection.generateCertificate) {
         Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
           get: function() {
-            if (arguments.length) {
-              return mozRTCPeerConnection.generateCertificate.apply(null,
-                  arguments);
-            }
             return mozRTCPeerConnection.generateCertificate;
           }
         });


### PR DESCRIPTION
**Description**
removes unnecessary code. As @jan-ivar pointed out, arguments.length for the getter will always be 0. Not sure how I came up with that code...

**Purpose**
reducing code size. We still want this to disappear.
