### PR TITLE
re-enable icetransports relay test in FF

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -2012,15 +2012,6 @@ test('iceTransportPolicy relay functionality', function(t) {
   driver.get('file://' + process.cwd() + '/test/testpage.html')
   .then(function() {
     t.pass('Page loaded');
-    return driver.executeScript(
-      'return adapter.browserDetails.browser === \'firefox\'');
-  })
-  .then(function(isFirefox) {
-    if (isFirefox) {
-      // TODO: Remove once supported in firefox.
-      t.skip('iceTransportPolicy is not implemented in Firefox yet.');
-      throw 'skip-test';
-    }
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {


### PR DESCRIPTION
this test was previously disabled because FF ESR was 38 and iceTransportPolicy was [implemented in FF 42](https://bugzilla.mozilla.org/show_bug.cgi?id=1187775)
