### PR TITLE
Shim away RTCSessionDescription/RTCIceCandidate.

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -191,9 +191,8 @@ var chromeShim = {
           webkitRTCPeerConnection.prototype[method] = function() {
             var args = arguments;
             var self = this;
-            var Frob = (method === 'addIceCandidate')?
-                RTCIceCandidate : RTCSessionDescription;
-            args[0] = new Frob(args[0]);
+            args[0] = new ((method === 'addIceCandidate')?
+                RTCIceCandidate : RTCSessionDescription)(args[0]);
             return new Promise(function(resolve, reject) {
               nativeMethod.apply(self, [args[0],
                   function() {

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -191,6 +191,9 @@ var chromeShim = {
           webkitRTCPeerConnection.prototype[method] = function() {
             var args = arguments;
             var self = this;
+            var Frob = (method === 'addIceCandidate')?
+                RTCIceCandidate : RTCSessionDescription;
+            args[0] = new Frob(args[0]);
             return new Promise(function(resolve, reject) {
               nativeMethod.apply(self, [args[0],
                   function() {

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -112,9 +112,8 @@ var firefoxShim = {
         .forEach(function(method) {
           var nativeMethod = RTCPeerConnection.prototype[method];
           RTCPeerConnection.prototype[method] = function() {
-            var Frob = (method === 'addIceCandidate')?
-                RTCIceCandidate : RTCSessionDescription;
-            arguments[0] = new Frob(arguments[0]);
+            arguments[0] = new ((method === 'addIceCandidate')?
+                RTCIceCandidate : RTCSessionDescription)(arguments[0]);
             return nativeMethod.apply(this, arguments);
           };
         });

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -106,6 +106,18 @@ var firefoxShim = {
       window.RTCSessionDescription = mozRTCSessionDescription;
       window.RTCIceCandidate = mozRTCIceCandidate;
     }
+
+    // shim away need for obsolete RTCIceCandidate/RTCSessionDescription.
+    ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
+        .forEach(function(method) {
+          var nativeMethod = RTCPeerConnection.prototype[method];
+          RTCPeerConnection.prototype[method] = function() {
+            var Frob = (method === 'addIceCandidate')?
+                RTCIceCandidate : RTCSessionDescription;
+            arguments[0] = new Frob(arguments[0]);
+            return nativeMethod.apply(this, arguments);
+          };
+        });
   },
 
   shimGetUserMedia: function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1460,10 +1460,11 @@ test('Basic connection establishment with promise', function(t) {
       }
     };
 
+    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+
     var addCandidate = function(pc, event) {
       if (event.candidate) {
-        var cand = new RTCIceCandidate(event.candidate);
-        pc.addIceCandidate(cand).then(function() {
+        pc.addIceCandidate(dictionary(event.candidate)).then(function() {
           // TODO: Decide if we are interested in adding all candidates
           // as passed tests.
           tc.pass('addIceCandidate ' + counter++);
@@ -1479,8 +1480,6 @@ test('Basic connection establishment with promise', function(t) {
     pc2.onicecandidate = function(event) {
       addCandidate(pc1, event);
     };
-
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
 
     var constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)

--- a/test/test.js
+++ b/test/test.js
@@ -1480,25 +1480,27 @@ test('Basic connection establishment with promise', function(t) {
       addCandidate(pc1, event);
     };
 
+    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+
     var constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
       pc1.createOffer().then(function(offer) {
         tc.pass('pc1.createOffer');
-        return pc1.setLocalDescription(offer);
+        return pc1.setLocalDescription(dictionary(offer));
       }).then(function() {
         tc.pass('pc1.setLocalDescription');
-        return pc2.setRemoteDescription(pc1.localDescription);
+        return pc2.setRemoteDescription(dictionary(pc1.localDescription));
       }).then(function() {
         tc.pass('pc2.setRemoteDescription');
         return pc2.createAnswer();
       }).then(function(answer) {
         tc.pass('pc2.createAnswer');
-        return pc2.setLocalDescription(answer);
+        return pc2.setLocalDescription(dictionary(answer));
       }).then(function() {
         tc.pass('pc2.setLocalDescription');
-        return pc1.setRemoteDescription(pc2.localDescription);
+        return pc1.setRemoteDescription(dictionary(pc2.localDescription));
       }).then(function() {
         tc.pass('pc1.setRemoteDescription');
       }).catch(function(err) {


### PR DESCRIPTION
**Description**
Shim implicit creation of (now redundant) `RTCSessionDescription`/`RTCIceCandidate` interfaces in `setLocalDescription`/`setLocalDescription`/`addIceCandidate`.

**Purpose**
https://github.com/w3c/webrtc-pc/pull/302. I started fixing this in Firefox, then realized people wouldn't benefit in years without having a polyfill.
