### PR TITLE
Edge: if mid is not defined, choose a random one

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -462,7 +462,7 @@ var edgeShim = {
             if (mid.length) {
               mid = mid[0].substr(6);
             } else {
-              mid = undefined;
+              mid = SDPUtils.generateIdentifier();
             }
 
             var cname;


### PR DESCRIPTION
since I saw @alvestrand merge https://github.com/w3c/webrtc-pc/pull/535 earlier today... ;-)
(wondering if that should also apply to rejected m-lines but _shrug_)
