### PR TITLE
Disable console logging by default

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -19,11 +19,11 @@
   module.exports.extractVersion = require('./utils').extractVersion;
   module.exports.disableLog = require('./utils').disableLog;
 
-  // Uncomment if you do not want any logging at all including the switch
-  // statement below. Can also be turned off in the browser via
-  // adapter.disableLog(true) but then logging from the switch statement below
-  // will still appear.
-  // require('./utils').disableLog(true);
+  // Comment out the line below if you want logging to occur, including logging
+  // for the switch statement below. Can also be turned on in the browser via
+  // adapter.disableLog(false), but then logging from the switch statement below
+  // will not appear.
+  require('./utils').disableLog(true);
 
   // Browser shims.
   var chromeShim = require('./chrome/chrome_shim') || null;


### PR DESCRIPTION
**Description**
Turns off logging to the `console` by default. Logging can still be re-enabled by calling `adapter.disableLog(false)`. 
Resolves https://github.com/webrtc/adapter/issues/68.

**Purpose**
Logging by default is not desirable functionality. For an example of _not_ logging to the console being standard convention, see this linting rule from ESLint: http://eslint.org/docs/rules/no-console. Here is an excerpt:

> In JavaScript that is designed to be executed in the browser, it’s considered a best practice to avoid using methods on console. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client. In general, calls using console should be stripped before being pushed to production.

As such, having logging enabled by default in `adapter.js` (which therefore logs the first "switch" statement of code in the browser, without the ability to turn it off) is fairly bad non-standard practice, and it requires editing the source or forking the project before using the code in production. The adapter code should be as widely usable as possible (and of course designed for the browser), so logging should be off by default.
