### PR TITLE
Do not modify input arguments

### DIFF
--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -63,14 +63,15 @@ module.exports = function() {
   };
 
   var getUserMedia_ = function(constraints, onSuccess, onError) {
-    if (constraints.audio) {
-      constraints.audio = constraintsToChrome_(constraints.audio);
+    var constraintsCopy = JSON.parse(JSON.stringify(constraints));
+    if (constraintsCopy.audio) {
+      constraintsCopy.audio = constraintsToChrome_(constraintsCopy.audio);
     }
-    if (constraints.video) {
-      constraints.video = constraintsToChrome_(constraints.video);
+    if (constraintsCopy.video) {
+      constraintsCopy.video = constraintsToChrome_(constraintsCopy.video);
     }
-    logging('chrome: ' + JSON.stringify(constraints));
-    return navigator.webkitGetUserMedia(constraints, onSuccess, onError);
+    logging('chrome: ' + JSON.stringify(constraintsCopy));
+    return navigator.webkitGetUserMedia(constraintsCopy, onSuccess, onError);
   };
   navigator.getUserMedia = getUserMedia_;
 

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -151,17 +151,18 @@ var firefoxShim = {
         }
         return c;
       };
+      var constraintsCopy = JSON.parse(JSON.stringify(constraints));
       if (browserDetails.version < 38) {
         logging('spec: ' + JSON.stringify(constraints));
-        if (constraints.audio) {
-          constraints.audio = constraintsToFF37_(constraints.audio);
+        if (constraintsCopy.audio) {
+          constraintsCopy.audio = constraintsToFF37_(constraintsCopy.audio);
         }
-        if (constraints.video) {
-          constraints.video = constraintsToFF37_(constraints.video);
+        if (constraintsCopy.video) {
+          constraintsCopy.video = constraintsToFF37_(constraintsCopy.video);
         }
-        logging('ff37: ' + JSON.stringify(constraints));
+        logging('ff37: ' + JSON.stringify(constraintsCopy));
       }
-      return navigator.mozGetUserMedia(constraints, onSuccess, onError);
+      return navigator.mozGetUserMedia(constraintsCopy, onSuccess, onError);
     };
 
     navigator.getUserMedia = getUserMedia_;

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -58,17 +58,18 @@ module.exports = function() {
       }
       return c;
     };
+    var constraintsCopy = JSON.parse(JSON.stringify(constraints));
     if (browserDetails.version < 38) {
       logging('spec: ' + JSON.stringify(constraints));
-      if (constraints.audio) {
-        constraints.audio = constraintsToFF37_(constraints.audio);
+      if (constraintsCopy.audio) {
+        constraintsCopy.audio = constraintsToFF37_(constraintsCopy.audio);
       }
-      if (constraints.video) {
-        constraints.video = constraintsToFF37_(constraints.video);
+      if (constraintsCopy.video) {
+        constraintsCopy.video = constraintsToFF37_(constraintsCopy.video);
       }
-      logging('ff37: ' + JSON.stringify(constraints));
+      logging('ff37: ' + JSON.stringify(constraintsCopy));
     }
-    return navigator.mozGetUserMedia(constraints, onSuccess, onError);
+    return navigator.mozGetUserMedia(constraintsCopy, onSuccess, onError);
   };
 
   navigator.getUserMedia = getUserMedia_;


### PR DESCRIPTION
**Description**

For example, if we submitted constraints.video.deviceId to Chrome, once getUserMedia returned our constraints would have been modified to constraints.video.mandatory.sourceId

**Purpose**

It's a party foul to modify input arguments, unless the spec mandates this behavior.  I don't believe it does.
