### PR TITLE
Shim maplike getStats support.

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -918,10 +918,12 @@ var edgeShim = {
       var cb = arguments.length > 1 && typeof arguments[1] === 'function' &&
           arguments[1];
       return new Promise(function(resolve) {
-        var results = {};
+        // shim getStats with maplike support
+        var results = new Map();
         Promise.all(promises).then(function(res) {
           res.forEach(function(result) {
             Object.keys(result).forEach(function(id) {
+              results.set(id, result[id]);
               results[id] = result[id];
             });
           });

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -113,6 +113,23 @@ var firefoxShim = {
             return nativeMethod.apply(this, arguments);
           };
         });
+
+    // shim getStats with maplike support
+    var makeMapStats = stats => {
+      var map = new Map();
+      Object.keys(stats).forEach(key => {
+        map.set(key, stats[key]);
+        map[key] = stats[key];
+      });
+      return map;
+    };
+
+    var nativeGetStats = RTCPeerConnection.prototype.getStats;
+    RTCPeerConnection.prototype.getStats = function(selector, onSucc, onErr) {
+      return nativeGetStats.apply(this, [selector || null])
+        .then(stats => makeMapStats(stats))
+        .then(onSucc, onErr);
+    };
   },
 
   shimGetUserMedia: function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1724,7 +1724,7 @@ test('call enumerateDevices', function(t) {
   });
 });
 
-// Test Chrome polyfill for getStats.
+// Test polyfill for getStats.
 test('getStats', function(t) {
   var driver = seleniumHelpers.buildDriver();
 
@@ -1741,13 +1741,21 @@ test('getStats', function(t) {
     .then(function(report) {
       window.testsEqualArray.push([typeof(report), 'object',
           'report is an object.']);
+      report.forEach((stat, key) => {
+        window.testsEqualArray.push([stat.id, key,
+            'report key matches stats id.']);
+      });
+      return report;
+    })
+    .then(function(report) {
+      // Test legacy behavior
       for (var key in report) {
         // This avoids problems with Firefox
         if (typeof(report[key]) === 'function') {
           continue;
         }
         window.testsEqualArray.push([report[key].id, key,
-            'report key matches stats id.']);
+            'legacy report key matches stats id.']);
       }
       callback(null);
     })


### PR DESCRIPTION
**Description**

Shims maplike getStats support in the three browsers, while still being backwards compatible.

**Purpose**

Firefox 48 [adds](https://bugzil.la/1213056) maplike getStats support, so here is a shim that lets adapter.js users use this right away without worry.

Note: had some trouble testing this in Edge, but trouble seemed unrelated to this patch, so I put this up to see if tests succeed there.
