### PR TITLE
Edge: add getSenders and getReceivers method

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -165,6 +165,24 @@ var edgeShim = {
       }
     };
 
+    window.RTCPeerConnection.prototype.getSenders = function() {
+      return this.transceivers.filter(function(transceiver) {
+        return !!transceiver.rtpSender;
+      })
+      .map(function(transceiver) {
+        return transceiver.rtpSender;
+      });
+    };
+
+    window.RTCPeerConnection.prototype.getReceivers = function() {
+      return this.transceivers.filter(function(transceiver) {
+        return !!transceiver.rtpReceiver;
+      })
+      .map(function(transceiver) {
+        return transceiver.rtpReceiver;
+      });
+    };
+
     // Determines the intersection of local and remote capabilities.
     window.RTCPeerConnection.prototype._getCommonCapabilities =
         function(localCapabilities, remoteCapabilities) {


### PR DESCRIPTION
**Description**
adds http://w3c.github.io/webrtc-pc/#widl-RTCPeerConnection-getSenders-sequence-RTCRtpSender and the corresponding getReceivers method. Trivial, this is where codereview with @pthatcherg pays off :-)

getTransceivers will be a little more effort though.
