### PR TITLE
Edge: parse rtx pt as well

### DIFF
--- a/src/js/edge/edge_sdp.js
+++ b/src/js/edge/edge_sdp.js
@@ -390,6 +390,7 @@ SDPUtils.parseRtpEncodingParameters = function(mediaSection) {
         ssrc: primarySsrc,
         codecPayloadType: parseInt(codec.parameters.apt, 10),
         rtx: {
+          payloadType: codec.payloadType,
           ssrc: secondarySsrc
         }
       };

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -147,6 +147,7 @@ test('parseRtpEncodingParameters', function(t) {
 
   t.ok(data[0].ssrc === 1734522595, 'parsed primary SSRC');
   t.ok(data[0].rtx, 'has RTX encoding');
+  t.ok(data[0].rtx.payloadType === 96, 'parsed rtx payloadType');
   t.ok(data[0].rtx.ssrc === 2715962409, 'parsed secondary SSRC for RTX');
   t.end();
 });


### PR DESCRIPTION
**Description**
turns out I forgot adding the payloadType to the rtx encoding parameters.
# funse
