### PR TITLE
use eslint-config-webrtc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -49,21 +49,10 @@
       "browser": true,
       "node": true
   },
-  "extends": "eslint:recommended",
+  "extends": ["eslint:recommended", "webrtc"],
   "globals": {
-    "MediaStream": true,
     "module": true,
-    "mozRTCPeerConnection": true,
-    "mozRTCSessionDescription": true,
-    "mozRTCIceCandidate": true,
     "require": true,
-    "RTCPeerConnection": true,
-    "RTCRtpSender": true,
-    "RTCRtpReceiver": true,
-    "RTCIceTransport": true,
-    "RTCDtlsTransport": true,
-    "RTCIceGatherer": true,
-    "webkitRTCPeerConnection": true,
     "process": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   },
   "devDependencies": {
     "chromedriver": "^2.16.0",
+    "eslint-config-webrtc": "^1.0.0",
+    "faucet": "0.0.1",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": ">=0.1.9",
@@ -30,7 +32,6 @@
     "grunt-githooks": "^0.3.1",
     "selenium-webdriver": "^2.52.0",
     "tape": "^4.0.0",
-    "travis-multirunner": "^3.0.1",
-    "faucet": "0.0.1"
+    "travis-multirunner": "^3.0.1"
   }
 }


### PR DESCRIPTION
I made a eslint shared config module for webrtc/ortc globals. Easier than specifying them everywhere.
