### PR TITLE
improve promise handling when callback method signature is used

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -206,22 +206,20 @@ var chromeShim = {
             var self = this;
             args[0] = new ((method === 'addIceCandidate')?
                 RTCIceCandidate : RTCSessionDescription)(args[0]);
-            return new Promise(function(resolve, reject) {
-              nativeMethod.apply(self, [args[0],
-                  function() {
-                    resolve();
-                    if (args.length >= 2) {
-                      args[1].apply(null, []);
-                    }
-                  },
-                  function(err) {
-                    reject(err);
-                    if (args.length >= 3) {
-                      args[2].apply(null, [err]);
-                    }
-                  }]
-                );
+            var promise = new Promise(function(resolve, reject) {
+              nativeMethod.apply(self, [args[0], resolve, reject]);
             });
+            if (args.length >= 2) {
+              promise.then(function() {
+                args[1].apply(null, []);
+              });
+              if (args.length >= 3) {
+                promise.catch(function(err) {
+                  args[2].apply(null, [err]);
+                });
+              }
+            }
+            return promise;
           };
         });
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1336,7 +1336,7 @@ test('Basic connection establishment', function(t) {
         var cand = new RTCIceCandidate(event.candidate);
         pc.addIceCandidate(cand,
           function() {
-            // TODO: Decide if we are intereted in adding all candidates
+            // TODO: Decide if we are interested in adding all candidates
             // as passed tests.
             tc.pass('addIceCandidate ' + counter++);
           },


### PR DESCRIPTION
**Description**

When callback functions (success and error) are provided, invoke these using `promise.then` and `promise.catch` instead of at resolve/reject time.

**Purpose**

By putting these into `then` and `catch` you can ensure that the promise chain is handled by the error handler, instead of causing `Uncaught error in promise chain` errors. I.e., If the promise is rejected, but it's handled by a callback, it should be done in the catch.
