### PR TITLE
use native RTCPeerConnection promises in Chrome 51

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -190,7 +190,7 @@ var chromeShim = {
         webkitRTCPeerConnection.prototype[method] = function() {
           var self = this;
           if (arguments.length < 1 || (arguments.length === 1 &&
-              typeof(arguments[0]) === 'object')) {
+              typeof arguments[0] === 'object')) {
             var opts = arguments.length === 1 ? arguments[0] : undefined;
             return new Promise(function(resolve, reject) {
               nativeMethod.apply(self, [resolve, reject, opts]);

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -183,46 +183,48 @@ var chromeShim = {
       });
     }
 
-    // add promise support
-    ['createOffer', 'createAnswer'].forEach(function(method) {
-      var nativeMethod = webkitRTCPeerConnection.prototype[method];
-      webkitRTCPeerConnection.prototype[method] = function() {
-        var self = this;
-        if (arguments.length < 1 || (arguments.length === 1 &&
-            typeof(arguments[0]) === 'object')) {
-          var opts = arguments.length === 1 ? arguments[0] : undefined;
-          return new Promise(function(resolve, reject) {
-            nativeMethod.apply(self, [resolve, reject, opts]);
-          });
-        }
-        return nativeMethod.apply(this, arguments);
-      };
-    });
+    // add promise support -- natively available in Chrome 51
+    if (browserDetails.version < 51) {
+      ['createOffer', 'createAnswer'].forEach(function(method) {
+        var nativeMethod = webkitRTCPeerConnection.prototype[method];
+        webkitRTCPeerConnection.prototype[method] = function() {
+          var self = this;
+          if (arguments.length < 1 || (arguments.length === 1 &&
+              typeof(arguments[0]) === 'object')) {
+            var opts = arguments.length === 1 ? arguments[0] : undefined;
+            return new Promise(function(resolve, reject) {
+              nativeMethod.apply(self, [resolve, reject, opts]);
+            });
+          }
+          return nativeMethod.apply(this, arguments);
+        };
+      });
 
-    ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
-        .forEach(function(method) {
-          var nativeMethod = webkitRTCPeerConnection.prototype[method];
-          webkitRTCPeerConnection.prototype[method] = function() {
-            var args = arguments;
-            var self = this;
-            args[0] = new ((method === 'addIceCandidate')?
-                RTCIceCandidate : RTCSessionDescription)(args[0]);
-            var promise = new Promise(function(resolve, reject) {
-              nativeMethod.apply(self, [args[0], resolve, reject]);
-            });
-            if (args.length < 2) {
-              return promise;
-            }
-            return promise.then(function() {
-              args[1].apply(null, []);
-            },
-            function(err) {
-              if (args.length >= 3) {
-                args[2].apply(null, [err]);
+      ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
+          .forEach(function(method) {
+            var nativeMethod = webkitRTCPeerConnection.prototype[method];
+            webkitRTCPeerConnection.prototype[method] = function() {
+              var args = arguments;
+              var self = this;
+              args[0] = new ((method === 'addIceCandidate')?
+                  RTCIceCandidate : RTCSessionDescription)(args[0]);
+              var promise = new Promise(function(resolve, reject) {
+                nativeMethod.apply(self, [args[0], resolve, reject]);
+              });
+              if (args.length < 2) {
+                return promise;
               }
-            });
-          };
-        });
+              return promise.then(function() {
+                args[1].apply(null, []);
+              },
+              function(err) {
+                if (args.length >= 3) {
+                  args[2].apply(null, [err]);
+                }
+              });
+            };
+          });
+    }
   },
 
   // Attach a media stream to an element.

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -206,7 +206,7 @@ var chromeShim = {
             webkitRTCPeerConnection.prototype[method] = function() {
               var args = arguments;
               var self = this;
-              args[0] = new ((method === 'addIceCandidate')?
+              args[0] = new ((method === 'addIceCandidate') ?
                   RTCIceCandidate : RTCSessionDescription)(args[0]);
               var promise = new Promise(function(resolve, reject) {
                 nativeMethod.apply(self, [args[0], resolve, reject]);


### PR DESCRIPTION
**Description**
does not attempt to shim promises in Chrome 51+

**Purpose**
make adapter superflous
