### PR TITLE
Shim NotAllowedError.

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -72,6 +72,7 @@
       // Export to the adapter global object visible in the browser.
       module.exports.browserShim = edgeShim;
 
+      edgeShim.shimGetUserMedia();
       edgeShim.shimPeerConnection();
       break;
     case 'safari':

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -115,7 +115,7 @@ module.exports = function() {
   var getUserMedia_ = (constraints, onSuccess, onError) =>
     shimConstraints_(constraints,
                      c => navigator.webkitGetUserMedia(c, onSuccess,
-                         e => Promise.reject(shimError_(e))));
+                         e => onError(shimError_(e))));
 
   navigator.getUserMedia = getUserMedia_;
 

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -101,9 +101,21 @@ module.exports = function() {
     return func(constraints);
   };
 
+  var shimError_ = e => ({
+    name: {PermissionDeniedError: 'NotAllowedError',
+           ConstraintNotSatisfiedError: 'OverconstrainedError'
+          }[e.name] || e.name,
+    message: e.message,
+    constraint: e.constraintName,
+    toString: function() {
+      return this.name + (this.message && ': ') + this.message;
+    }
+  });
+
   var getUserMedia_ = (constraints, onSuccess, onError) =>
     shimConstraints_(constraints,
-                     c => navigator.webkitGetUserMedia(c, onSuccess, onError));
+                     c => navigator.webkitGetUserMedia(c, onSuccess,
+                         e => Promise.reject(shimError_(e))));
 
   navigator.getUserMedia = getUserMedia_;
 
@@ -145,8 +157,8 @@ module.exports = function() {
     // constraints.
     var origGetUserMedia = navigator.mediaDevices.getUserMedia.
         bind(navigator.mediaDevices);
-    navigator.mediaDevices.getUserMedia = constraints =>
-        shimConstraints_(constraints, c => origGetUserMedia(c));
+    navigator.mediaDevices.getUserMedia = cs => shimConstraints_(cs,
+        c => origGetUserMedia(c).catch(e => Promise.reject(shimError_(e))));
   }
 
   // Dummy devicechange event methods.

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -990,6 +990,7 @@ var edgeShim = {
 // Expose public methods.
 module.exports = {
   shimPeerConnection: edgeShim.shimPeerConnection,
+  shimGetUserMedia: require('./getusermedia'),
   attachMediaStream: edgeShim.attachMediaStream,
   reattachMediaStream: edgeShim.reattachMediaStream
 };

--- a/src/js/edge/getusermedia.js
+++ b/src/js/edge/getusermedia.js
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2016 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+var logging = require('../utils').log;
+var browserDetails = require('../utils').browserDetails;
+
+// Expose public methods.
+module.exports = function() {
+  var shimError_ = e => ({
+    name: {PermissionDeniedError: 'NotAllowedError'}[e.name] || e.name,
+    message: e.message,
+    constraint: e.constraint,
+    toString: function() {
+      return this.name;
+    }
+  });
+
+  // getUserMedia error shim.
+  var origGetUserMedia = navigator.mediaDevices.getUserMedia.
+      bind(navigator.mediaDevices);
+  navigator.mediaDevices.getUserMedia = c =>
+      origGetUserMedia(c).catch(e => Promise.reject(shimError_(e)));
+};

--- a/src/js/edge/getusermedia.js
+++ b/src/js/edge/getusermedia.js
@@ -8,9 +8,6 @@
  /* eslint-env node */
 'use strict';
 
-var logging = require('../utils').log;
-var browserDetails = require('../utils').browserDetails;
-
 // Expose public methods.
 module.exports = function() {
   var shimError_ = e => ({

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -13,6 +13,22 @@ var browserDetails = require('../utils').browserDetails;
 
 // Expose public methods.
 module.exports = function() {
+  var shimError_ = e => ({
+    name: {
+      SecurityError: 'NotAllowedError',
+      PermissionDeniedError: 'NotAllowedError'
+    }[e.name] || e.name,
+    message: {
+      'The operation is insecure.': 'The request is not allowed by the user ' +
+      'agent or the platform in the current context.',
+    }[e.message] || e.message,
+    constraint: e.constraint,
+    toString: function() {
+      return this.name + (this.message && ': ') + this.message;
+    }
+  });
+
+
   // getUserMedia constraints shim.
   var getUserMedia_ = function(constraints, onSuccess, onError) {
     var constraintsToFF37_ = function(c) {
@@ -69,7 +85,8 @@ module.exports = function() {
       }
       logging('ff37: ' + JSON.stringify(constraints));
     }
-    return navigator.mozGetUserMedia(constraints, onSuccess, onError);
+    return navigator.mozGetUserMedia(constraints, onSuccess,
+                                     e => onError(shimError_(e)));
   };
 
   navigator.getUserMedia = getUserMedia_;
@@ -111,5 +128,11 @@ module.exports = function() {
         throw e;
       });
     };
+  }
+  if (browserDetails.version < 49) {
+    var origGetUserMedia = navigator.mediaDevices.getUserMedia.
+        bind(navigator.mediaDevices);
+    navigator.mediaDevices.getUserMedia = c =>
+        origGetUserMedia(c).catch(e => Promise.reject(shimError_(e)));
   }
 };

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -20,7 +20,7 @@ module.exports = function() {
     }[e.name] || e.name,
     message: {
       'The operation is insecure.': 'The request is not allowed by the user ' +
-      'agent or the platform in the current context.',
+      'agent or the platform in the current context.'
     }[e.message] || e.message,
     constraint: e.constraint,
     toString: function() {


### PR DESCRIPTION
**Description**
Shim getUserMedia to fail with NotAllowedError (Chrome, Firefox) and OverconstrainedError (Chrome), to match the spec.

**Purpose**
Make it easier to handle errors across browsers and versions uniformly.
