### PR TITLE
shim away RTCSessionDescription/RTCIcecandidate

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -206,8 +206,6 @@ var chromeShim = {
             webkitRTCPeerConnection.prototype[method] = function() {
               var args = arguments;
               var self = this;
-              args[0] = new ((method === 'addIceCandidate') ?
-                  RTCIceCandidate : RTCSessionDescription)(args[0]);
               var promise = new Promise(function(resolve, reject) {
                 nativeMethod.apply(self, [args[0], resolve, reject]);
               });
@@ -225,6 +223,17 @@ var chromeShim = {
             };
           });
     }
+
+    // shim implicit creation of RTCSessionDescription/RTCIceCandidate
+    ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
+        .forEach(function(method) {
+          var nativeMethod = webkitRTCPeerConnection.prototype[method];
+          webkitRTCPeerConnection.prototype[method] = function() {
+            arguments[0] = new ((method === 'addIceCandidate') ?
+                RTCIceCandidate : RTCSessionDescription)(arguments[0]);
+            return nativeMethod.apply(this, arguments);
+          };
+        });
   },
 
   // Attach a media stream to an element.


### PR DESCRIPTION
basically #266 but separate so it doesn't collide with #288
This is still required in Chrome 51, even though not if promises are used. See [here](https://bugs.chromium.org/p/chromium/issues/detail?id=612118)

cc @jan-ivar, sorry for breaking this
