### PR TITLE
dont use arrow functions (yet)

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -136,10 +136,12 @@ var chromeShim = {
         };
 
         // shim getStats with maplike support
-        var makeMapStats = (stats, legacyStats) => {
-          var map = new Map(Object.keys(stats).map(key => [key, stats[key]]));
+        var makeMapStats = function(stats, legacyStats) {
+          var map = new Map(Object.keys(stats).map(function(key) {
+            return[key, stats[key]];
+          }));
           legacyStats = legacyStats || stats;
-          Object.keys(legacyStats).forEach(key => {
+          Object.keys(legacyStats).forEach(function(key) {
             map[key] = legacyStats[key];
           });
           return map;
@@ -157,15 +159,17 @@ var chromeShim = {
         // promise-support
         return new Promise(function(resolve, reject) {
           if (args.length === 1 && typeof selector === 'object') {
-            origGetStats.apply(self,
-                [response => resolve(makeMapStats(fixChromeStats_(response))),
-                 reject]);
+            origGetStats.apply(self, [
+              function(response) {
+                resolve(makeMapStats(fixChromeStats_(response)));
+              }, reject]);
           } else {
             // Preserve legacy chrome stats only on legacy access of stats obj
-            origGetStats.apply(self,
-                [response => resolve(makeMapStats(fixChromeStats_(response),
-                                                  response.result())),
-                 reject]);
+            origGetStats.apply(self, [
+              function(response) {
+                resolve(makeMapStats(fixChromeStats_(response),
+                    response.result()));
+              }, reject]);
           }
         }).then(successCallback, errorCallback);
       };

--- a/src/js/edge/getusermedia.js
+++ b/src/js/edge/getusermedia.js
@@ -10,18 +10,23 @@
 
 // Expose public methods.
 module.exports = function() {
-  var shimError_ = e => ({
-    name: {PermissionDeniedError: 'NotAllowedError'}[e.name] || e.name,
-    message: e.message,
-    constraint: e.constraint,
-    toString: function() {
-      return this.name;
-    }
-  });
+  var shimError_ = function(e) {
+    return {
+      name: {PermissionDeniedError: 'NotAllowedError'}[e.name] || e.name,
+      message: e.message,
+      constraint: e.constraint,
+      toString: function() {
+        return this.name;
+      }
+    };
+  };
 
   // getUserMedia error shim.
   var origGetUserMedia = navigator.mediaDevices.getUserMedia.
       bind(navigator.mediaDevices);
-  navigator.mediaDevices.getUserMedia = c =>
-      origGetUserMedia(c).catch(e => Promise.reject(shimError_(e)));
+  navigator.mediaDevices.getUserMedia = function(c) {
+    return origGetUserMedia(c).catch(function(e) {
+      return Promise.reject(shimError_(e));
+    });
+  };
 };

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -119,9 +119,9 @@ var firefoxShim = {
         });
 
     // shim getStats with maplike support
-    var makeMapStats = stats => {
+    var makeMapStats = function(stats) {
       var map = new Map();
-      Object.keys(stats).forEach(key => {
+      Object.keys(stats).forEach(function(key) {
         map.set(key, stats[key]);
         map[key] = stats[key];
       });
@@ -131,7 +131,9 @@ var firefoxShim = {
     var nativeGetStats = RTCPeerConnection.prototype.getStats;
     RTCPeerConnection.prototype.getStats = function(selector, onSucc, onErr) {
       return nativeGetStats.apply(this, [selector || null])
-        .then(stats => makeMapStats(stats))
+        .then(function(stats) {
+          return makeMapStats(stats);
+        })
         .then(onSucc, onErr);
     };
   },


### PR DESCRIPTION
**Description**
ES6 breaks things like #297. While I'm in favor of doing that we should make that change at a major version, not a minor one.

@jan-ivar: don't worry, there is a [codemod to arrow-ify things](https://github.com/cpojer/js-codemod/blob/master/transforms/arrow-function.js) ;-)
