### PR TITLE
Crude initial attempt to create ES5 safe targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -54,9 +54,71 @@ module.exports = function(grunt) {
           ignore: [
             './src/js/edge/edge_shim.js',
             './src/js/edge/edge_sdp.js'
-          ],
+          ]
         }
       },
+      // The following entries duplicate the entries above but use babelify
+      // to create versions safe for old browsers.
+      adapterGlobalObjectES5: {
+        src: ['./src/js/adapter_core.js'],
+        dest: './out/adapter_es5.js',
+        options: {
+          browserifyOptions: {
+            // Exposes shim methods in a global object to the browser.
+            // The tests require this.
+            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
+            // from package.json once we have a better NPM name.
+            standalone: 'adapter',
+            transform: 'babelify'
+          }
+        }
+      },
+      // Use this if you do not want adapter to expose anything to the global
+      // scope.
+      adapterAndNoGlobalObjectES5: {
+        src: ['./src/js/adapter_core.js'],
+        dest: './out/adapter_no_global_es5.js',
+        options: {
+          browserifyOptions: {
+            transform: 'babelify'
+          }
+        }
+      },
+      // Use this if you do not want MS edge shim to be included.
+      adapterNoEdgeES5: {
+        src: ['./src/js/adapter_core.js'],
+        dest: './out/adapter_no_edge_es5.js',
+        options: {
+          // These files will be skipped.
+          ignore: [
+            './src/js/edge/edge_shim.js',
+            './src/js/edge/edge_sdp.js'
+          ],
+          browserifyOptions: {
+            // Exposes the shim in a global object to the browser.
+            // The tests require this.
+            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
+            // from package.json once we have a better NPM name.
+            standalone: 'adapter',
+            transform: 'babelify'
+          }
+        }
+      },
+      // Use this if you do not want MS edge shim to be included and do not
+      // want adapter to expose anything to the global scope.
+      adapterNoEdgeAndNoGlobalObjectES5: {
+        src: ['./src/js/adapter_core.js'],
+        dest: './out/adapter_no_edge_no_global_es5.js',
+        options: {
+          ignore: [
+            './src/js/edge/edge_shim.js',
+            './src/js/edge/edge_sdp.js'
+          ],
+          browserifyOptions: {
+            transform: 'babelify'
+          }
+        }
+      }
     },
     githooks: {
       all: {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
   },
+  "babel" : {
+    "presets": ["es2015"]
+  },
   "authors": [
     "The WebRTC project authors (https://www.webrtc.org/)"
   ],
@@ -22,6 +25,8 @@
     "sdp": "^1.0.0"
   },
   "devDependencies": {
+    "babel-preset-es2015": "^6.6.0",
+    "babelify": "^7.3.0",
     "chromedriver": "^2.16.0",
     "eslint-config-webrtc": "^1.0.0",
     "faucet": "0.0.1",


### PR DESCRIPTION
Add 4 "duplicate" targets which are babelified while being browserified.

This is in order to automatically create safe versions for old browsers without restricting coders to pre-ES6 sources.
