### PR TITLE
Publish ES5 compatible releases on gh-pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,8 +1,5 @@
 'use strict';
 
-/* For jshint: */
-/* globals module, require */
-
 module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -14,8 +11,6 @@ module.exports = function(grunt) {
           browserifyOptions: {
             // Exposes shim methods in a global object to the browser.
             // The tests require this.
-            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
-            // from package.json once we have a better NPM name.
             standalone: 'adapter'
           }
         }
@@ -38,9 +33,6 @@ module.exports = function(grunt) {
           ],
           browserifyOptions: {
             // Exposes the shim in a global object to the browser.
-            // The tests require this.
-            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
-            // from package.json once we have a better NPM name.
             standalone: 'adapter'
           }
         }
@@ -65,9 +57,6 @@ module.exports = function(grunt) {
         options: {
           browserifyOptions: {
             // Exposes shim methods in a global object to the browser.
-            // The tests require this.
-            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
-            // from package.json once we have a better NPM name.
             standalone: 'adapter',
             transform: 'babelify'
           }
@@ -96,9 +85,6 @@ module.exports = function(grunt) {
           ],
           browserifyOptions: {
             // Exposes the shim in a global object to the browser.
-            // The tests require this.
-            // TODO: Replace adapter with <%= pkg.name %>' which uses the name
-            // from package.json once we have a better NPM name.
             standalone: 'adapter',
             transform: 'babelify'
           }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "preversion": "git stash && git checkout master && git pull && npm test | faucet && git checkout -B bumpVersion",
     "version": "grunt build",
-    "postversion": "git push --force --set-upstream origin bumpVersion --follow-tags && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git checkout gh-pages && git pull && cp out/adapter.js . && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir adapter-`$GITTAG`-variants && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
+    "postversion": "git push --force --set-upstream origin bumpVersion --follow-tags && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git checkout gh-pages && git pull && cp out/adapter_es5.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*_.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
     "test": "grunt && node test/run-tests.js"
   },


### PR DESCRIPTION
**Description**
- `adapter.js` in the gh-pages root will now be based on `adapter_es5.js` target.
- This in turn means the versioned files (`adapter-1.2.0js`) will also be based on the `adapter_es5.js` target.
- adapter-latest.js will be linked to the latest versioned file thus it will also be `adapter_es5.js` based.
- The `adapter.js` file in the `out/` folder as well as `adapter-<version>-variants` folder on the gh-pages branch will be the ES6 version.

**Purpose**
Ensure we do not break in browsers/environments that do no support ES6.
