### PR TITLE
Fully disable all console logging by default

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -19,11 +19,11 @@
   module.exports.extractVersion = require('./utils').extractVersion;
   module.exports.disableLog = require('./utils').disableLog;
 
-  // Comment out the line below if you want logging to occur, including logging
+  // Uncomment the line below if you want logging to occur, including logging
   // for the switch statement below. Can also be turned on in the browser via
   // adapter.disableLog(false), but then logging from the switch statement below
   // will not appear.
-  require('./utils').disableLog(true);
+  // require('./utils').disableLog(false);
 
   // Browser shims.
   var chromeShim = require('./chrome/chrome_shim') || null;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -8,7 +8,7 @@
  /* eslint-env node */
 'use strict';
 
-var logDisabled_ = false;
+var logDisabled_ = true;
 
 // Utility methods.
 var utils = {


### PR DESCRIPTION
**Description**
In this PR of mine https://github.com/webrtc/adapter/pull/268, I attempted to disable console logging by default, but there is one spot that I missed:  within the `utils` module, there is a logging statement (which logs whether the browser is below the minimum supported version). As such, we have to properly initialize our logging as disabled _within_ the `utils` module, rather than overwriting the logging setting as disabled only after it's imported in the core module.

**Purpose**
We do not want console logging to be happening anywhere by default, since it is considered bad practice in production code. Fully resolves https://github.com/webrtc/adapter/issues/68 and finishes off what was intended here https://github.com/webrtc/adapter/pull/268#issue-148587548. Please see the **Purpose** section there for further clarification.
