### PR TITLE
Remove es6 arrow functions, add specific babel preset and npm 3+ is now required

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -58,7 +58,7 @@ module.exports = function(grunt) {
           browserifyOptions: {
             // Exposes shim methods in a global object to the browser.
             standalone: 'adapter',
-            transform: 'babelify'
+            transform: [['babelify', {'presets': ['es2015']}]]
           }
         }
       },
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
         dest: './out/adapter_no_global_es5.js',
         options: {
           browserifyOptions: {
-            transform: [['babelify', {"presets": ["es2015"]}]]
+            transform: [['babelify', {'presets': ['es2015']}]]
           }
         }
       },
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
           browserifyOptions: {
             // Exposes the shim in a global object to the browser.
             standalone: 'adapter',
-            transform: [['babelify', {"presets": ["es2015"]}]]
+            transform: [['babelify', {'presets': ['es2015']}]]
           }
         }
       },
@@ -101,7 +101,7 @@ module.exports = function(grunt) {
             './src/js/edge/edge_sdp.js'
           ],
           browserifyOptions: {
-            transform: [['babelify', {"presets": ["es2015"]}]]
+            transform: [['babelify', {'presets': ['es2015']}]]
           }
         }
       }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
         dest: './out/adapter_no_global_es5.js',
         options: {
           browserifyOptions: {
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       },
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
           browserifyOptions: {
             // Exposes the shim in a global object to the browser.
             standalone: 'adapter',
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       },
@@ -101,7 +101,7 @@ module.exports = function(grunt) {
             './src/js/edge/edge_sdp.js'
           ],
           browserifyOptions: {
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   "dependencies": {
     "sdp": "^1.0.0"
   },
+  "engines" : {
+    "npm" : "~3.0.0"
+  },
   "devDependencies": {
     "babel-preset-es2015": "^6.6.0",
     "babelify": "^7.3.0",

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -13,21 +13,22 @@ var browserDetails = require('../utils').browserDetails;
 
 // Expose public methods.
 module.exports = function() {
-  var shimError_ = e => ({
-    name: {
-      SecurityError: 'NotAllowedError',
-      PermissionDeniedError: 'NotAllowedError'
-    }[e.name] || e.name,
-    message: {
-      'The operation is insecure.': 'The request is not allowed by the user ' +
-      'agent or the platform in the current context.'
-    }[e.message] || e.message,
-    constraint: e.constraint,
-    toString: function() {
-      return this.name + (this.message && ': ') + this.message;
-    }
-  });
-
+  var shimError_ = function(e) {
+    return {
+      name: {
+        SecurityError: 'NotAllowedError',
+        PermissionDeniedError: 'NotAllowedError'
+      }[e.name] || e.name,
+      message: {
+        'The operation is insecure.': 'The request is not allowed by the ' +
+        'user agent or the platform in the current context.'
+      }[e.message] || e.message,
+      constraint: e.constraint,
+      toString: function() {
+        return this.name + (this.message && ': ') + this.message;
+      }
+    };
+  };
 
   // getUserMedia constraints shim.
   var getUserMedia_ = function(constraints, onSuccess, onError) {
@@ -85,8 +86,9 @@ module.exports = function() {
       }
       logging('ff37: ' + JSON.stringify(constraints));
     }
-    return navigator.mozGetUserMedia(constraints, onSuccess,
-                                     e => onError(shimError_(e)));
+    return navigator.mozGetUserMedia(constraints, onSuccess, function(e) {
+      onError(shimError_(e));
+    });
   };
 
   navigator.getUserMedia = getUserMedia_;
@@ -132,7 +134,10 @@ module.exports = function() {
   if (browserDetails.version < 49) {
     var origGetUserMedia = navigator.mediaDevices.getUserMedia.
         bind(navigator.mediaDevices);
-    navigator.mediaDevices.getUserMedia = c =>
-        origGetUserMedia(c).catch(e => Promise.reject(shimError_(e)));
+    navigator.mediaDevices.getUserMedia = function(c) {
+      origGetUserMedia(c).catch(function(e) {
+        return Promise.reject(shimError_(e));
+      });
+    };
   }
 };

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -135,7 +135,7 @@ module.exports = function() {
     var origGetUserMedia = navigator.mediaDevices.getUserMedia.
         bind(navigator.mediaDevices);
     navigator.mediaDevices.getUserMedia = function(c) {
-      origGetUserMedia(c).catch(function(e) {
+      return origGetUserMedia(c).catch(function(e) {
         return Promise.reject(shimError_(e));
       });
     };


### PR DESCRIPTION
**Description**
- Be ES5 compliant since do not need any ES6 features yet (nice to have to make code more compact but not needed).
- Indicate that we expect npm to be at least 3.0.0
- Add specific babel preset to ensure better compatibility when included in other projects. Fixes #309 

**Purpose**
Make adapter.js easier to use.
…
