### PR TITLE
Move 'babelify' settings into grunt file to isolate from outside world

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
             // TODO: Replace adapter with <%= pkg.name %>' which uses the name
             // from package.json once we have a better NPM name.
             standalone: 'adapter',
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       },
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
         dest: './out/adapter_no_global_es5.js',
         options: {
           browserifyOptions: {
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       },
@@ -100,7 +100,7 @@ module.exports = function(grunt) {
             // TODO: Replace adapter with <%= pkg.name %>' which uses the name
             // from package.json once we have a better NPM name.
             standalone: 'adapter',
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       },
@@ -115,7 +115,7 @@ module.exports = function(grunt) {
             './src/js/edge/edge_sdp.js'
           ],
           browserifyOptions: {
-            transform: 'babelify'
+            transform: [['babelify', {"presets": ["es2015"]}]]
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,6 @@
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
   },
-  "babel" : {
-    "presets": ["es2015"]
-  },
   "authors": [
     "The WebRTC project authors (https://www.webrtc.org/)"
   ],


### PR DESCRIPTION
Move 'babelify' settings into grunt file to isolate from outside world

It is reported that putting babelify settings into package.json can 'contaminate' other NPM projects, so the settings are moved inline into the grunt config.
