### PR TITLE
Fix publish copy routine, use out/adapter.js as adapter.js rather than es5

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,18 +8,13 @@
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
   "authors": [
     "The WebRTC project authors (https://www.webrtc.org/)"
   ],
   "scripts": {
     "preversion": "git stash && git checkout master && git pull && npm test | faucet && git checkout -B bumpVersion",
     "version": "grunt build",
-    "postversion": "git push --force --set-upstream origin bumpVersion --follow-tags && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git checkout gh-pages && git pull && cp out/adapter_es5.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*_.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
+    "postversion": "git push --force --set-upstream origin bumpVersion --follow-tags && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
     "test": "grunt && node test/run-tests.js"
   },


### PR DESCRIPTION
**Description**
Remove global babel preset since it breaks builds, now uses only Gruntfile.js presets.
Use out/adapter.js for gh-pages rather than the es5 target since we should now be es5 complaint regardless since just creating es5 compliant targets does not help when trying to build es6 code to es5 compliant targets when build environments only support es5 (true for projects having adapter.js as a dependency)

**Purpose**
Make adapter.js universally usable ;)
