### PR TITLE
Replace Firefox 44+'s deprecation warning with unprefixed version.

### DIFF
--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -91,12 +91,10 @@ module.exports = function() {
     });
   };
 
-  navigator.getUserMedia = getUserMedia_;
-
   // Returns the result of getUserMedia as a Promise.
   var getUserMediaPromise_ = function(constraints) {
     return new Promise(function(resolve, reject) {
-      navigator.getUserMedia(constraints, resolve, reject);
+      getUserMedia_(constraints, resolve, reject);
     });
   };
 
@@ -138,6 +136,16 @@ module.exports = function() {
       return origGetUserMedia(c).catch(function(e) {
         return Promise.reject(shimError_(e));
       });
+    };
+  }
+  if (browserDetails.version < 44) {
+    navigator.getUserMedia = getUserMedia_;
+  } else {
+    navigator.getUserMedia = function(constraints, onSuccess, onError) {
+      // Replace Firefox 44+'s deprecation warning with unprefixed version.
+      console.warn('navigator.getUserMedia has been replaced by ' +
+                   'navigator.mediaDevices.getUserMedia');
+      navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
     };
   }
 };

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -138,14 +138,13 @@ module.exports = function() {
       });
     };
   }
-  if (browserDetails.version < 44) {
-    navigator.getUserMedia = getUserMedia_;
-  } else {
-    navigator.getUserMedia = function(constraints, onSuccess, onError) {
-      // Replace Firefox 44+'s deprecation warning with unprefixed version.
-      console.warn('navigator.getUserMedia has been replaced by ' +
-                   'navigator.mediaDevices.getUserMedia');
-      navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
-    };
-  }
+  navigator.getUserMedia = function(constraints, onSuccess, onError) {
+    if (browserDetails.version < 44) {
+      return getUserMedia_(constraints, onSuccess, onError);
+    }
+    // Replace Firefox 44+'s deprecation warning with unprefixed version.
+    console.warn('navigator.getUserMedia has been replaced by ' +
+                 'navigator.mediaDevices.getUserMedia');
+    navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
+  };
 };


### PR DESCRIPTION
**Description**
Remove the 'moz'-prefix from Firefox's deprecation warning when people use `navigator.getUserMedia`.

**Purpose**
Avoid confusion and close https://github.com/webrtc/adapter/issues/310.
