### PR TITLE
Remove babel since we should now be es5 compliant

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,62 +48,6 @@ module.exports = function(grunt) {
             './src/js/edge/edge_sdp.js'
           ]
         }
-      },
-      // The following entries duplicate the entries above but use babelify
-      // to create versions safe for old browsers.
-      adapterGlobalObjectES5: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_es5.js',
-        options: {
-          browserifyOptions: {
-            // Exposes shim methods in a global object to the browser.
-            standalone: 'adapter',
-            transform: [['babelify', {'presets': ['es2015']}]]
-          }
-        }
-      },
-      // Use this if you do not want adapter to expose anything to the global
-      // scope.
-      adapterAndNoGlobalObjectES5: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_no_global_es5.js',
-        options: {
-          browserifyOptions: {
-            transform: [['babelify', {'presets': ['es2015']}]]
-          }
-        }
-      },
-      // Use this if you do not want MS edge shim to be included.
-      adapterNoEdgeES5: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_no_edge_es5.js',
-        options: {
-          // These files will be skipped.
-          ignore: [
-            './src/js/edge/edge_shim.js',
-            './src/js/edge/edge_sdp.js'
-          ],
-          browserifyOptions: {
-            // Exposes the shim in a global object to the browser.
-            standalone: 'adapter',
-            transform: [['babelify', {'presets': ['es2015']}]]
-          }
-        }
-      },
-      // Use this if you do not want MS edge shim to be included and do not
-      // want adapter to expose anything to the global scope.
-      adapterNoEdgeAndNoGlobalObjectES5: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_no_edge_no_global_es5.js',
-        options: {
-          ignore: [
-            './src/js/edge/edge_shim.js',
-            './src/js/edge/edge_sdp.js'
-          ],
-          browserifyOptions: {
-            transform: [['babelify', {'presets': ['es2015']}]]
-          }
-        }
       }
     },
     githooks: {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
     "prepublish": "grunt build",
     "test": "grunt && node test/run-tests.js"
   },
-  "babel": {
-    "presets": [
-      "es2015"
-    ]
-  },
   "dependencies": {
     "sdp": "^1.0.0"
   },
@@ -30,8 +25,6 @@
     "npm": "~3.0.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.6.0",
-    "babelify": "^7.3.0",
     "chromedriver": "^2.16.0",
     "eslint-config-webrtc": "^1.0.0",
     "faucet": "0.0.1",


### PR DESCRIPTION
**Description**
Remove due to not needing it anymore as long as we stick with es5 conventions.

**Purpose**
Reduce complexity and dependencies.

CC @fippo @dansullivan86 @davies147
