### PR TITLE
allow ice-lite without candidates

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -390,7 +390,9 @@ var edgeShim = {
                   // ice-lite only includes host candidates in the SDP so we can
                   // use setRemoteCandidates (which implies an
                   // RTCIceCandidateComplete)
-                  iceTransport.setRemoteCandidates(cands);
+                  if (cands.length) {
+                    iceTransport.setRemoteCandidates(cands);
+                  }
                 }
                 iceTransport.start(iceGatherer, remoteIceParameters,
                     isIceLite ? 'controlling' : 'controlled');
@@ -595,7 +597,7 @@ var edgeShim = {
                   remoteCapabilities;
               self.transceivers[sdpMLineIndex].cname = cname;
 
-              if (isIceLite || isComplete) {
+              if ((isIceLite || isComplete) && cands.length) {
                 iceTransport.setRemoteCandidates(cands);
               }
               iceTransport.start(iceGatherer, remoteIceParameters,


### PR DESCRIPTION
i'm not sure if 5245 really allows ice-lite with no candidates and using trickle.
Previously, my interpretation was 'no'. On what basis does hangouts combine trickle and lite @juberti @pthatcherg?
