### PR TITLE
move null candidate shim

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -228,14 +228,6 @@ var chromeShim = {
           });
     }
 
-    // support for addIceCandidate(null)
-    var nativeAddIceCandidate =
-        RTCPeerConnection.prototype.addIceCandidate;
-    RTCPeerConnection.prototype.addIceCandidate = function() {
-      return arguments[0] === null ? Promise.resolve()
-          : nativeAddIceCandidate.apply(this, arguments);
-    };
-
     // shim implicit creation of RTCSessionDescription/RTCIceCandidate
     ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
         .forEach(function(method) {
@@ -246,6 +238,14 @@ var chromeShim = {
             return nativeMethod.apply(this, arguments);
           };
         });
+
+    // support for addIceCandidate(null)
+    var nativeAddIceCandidate =
+        RTCPeerConnection.prototype.addIceCandidate;
+    RTCPeerConnection.prototype.addIceCandidate = function() {
+      return arguments[0] === null ? Promise.resolve()
+          : nativeAddIceCandidate.apply(this, arguments);
+    };
   },
 
   // Attach a media stream to an element.

--- a/test/test.js
+++ b/test/test.js
@@ -1686,6 +1686,35 @@ test('Basic connection establishment with datachannel', function(t) {
   });
 });
 
+test('addIceCandidate with null', function(t) {
+  var driver = seleniumHelpers.buildDriver();
+
+  var testDefinition = function() {
+    var callback = arguments[arguments.length - 1];
+
+    var pc1 = new RTCPeerConnection(null);
+    pc1.addIceCandidate(null)
+    .then(callback)
+    .catch(callback);
+  };
+  // Run test.
+  seleniumHelpers.loadTestPage(driver)
+  .then(function() {
+    t.pass('Page loaded');
+    return driver.executeAsyncScript(testDefinition);
+  })
+  .then(function(err) {
+    t.ok(err === null, 'addIceCandidate(null) resolves');
+    t.end();
+  })
+  .then(null, function(err) {
+    if (err !== 'skip-test') {
+      t.fail(err);
+    }
+    t.end();
+  });
+});
+
 test('call enumerateDevices', function(t) {
   var driver = seleniumHelpers.buildDriver();
 


### PR DESCRIPTION
the order of shimming things is important. The Firefox shim does it right, Chrome does not.
The null candidate has to be ignored at the outermost layer of this little onion, otherwise the implicit creation shim tries to call RTCIceCandidate(null) which errors.
