### PR TITLE
remove attachmediastream and reattachmediastream

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -246,27 +246,6 @@ var chromeShim = {
       return arguments[0] === null ? Promise.resolve()
           : nativeAddIceCandidate.apply(this, arguments);
     };
-  },
-
-  // Attach a media stream to an element.
-  attachMediaStream: function(element, stream) {
-    logging('DEPRECATED, attachMediaStream will soon be removed.');
-    if (browserDetails.version >= 43) {
-      element.srcObject = stream;
-    } else if (typeof element.src !== 'undefined') {
-      element.src = URL.createObjectURL(stream);
-    } else {
-      logging('Error attaching stream to element.');
-    }
-  },
-
-  reattachMediaStream: function(to, from) {
-    logging('DEPRECATED, reattachMediaStream will soon be removed.');
-    if (browserDetails.version >= 43) {
-      to.srcObject = from.srcObject;
-    } else {
-      to.src = from.src;
-    }
   }
 };
 
@@ -277,7 +256,5 @@ module.exports = {
   shimOnTrack: chromeShim.shimOnTrack,
   shimSourceObject: chromeShim.shimSourceObject,
   shimPeerConnection: chromeShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia'),
-  attachMediaStream: chromeShim.attachMediaStream,
-  reattachMediaStream: chromeShim.reattachMediaStream
+  shimGetUserMedia: require('./getusermedia')
 };

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -9,7 +9,6 @@
 'use strict';
 
 var SDPUtils = require('sdp');
-var logging = require('../utils').log;
 
 var edgeShim = {
   shimPeerConnection: function() {
@@ -1026,24 +1025,11 @@ var edgeShim = {
         });
       });
     };
-  },
-
-  // Attach a media stream to an element.
-  attachMediaStream: function(element, stream) {
-    logging('DEPRECATED, attachMediaStream will soon be removed.');
-    element.srcObject = stream;
-  },
-
-  reattachMediaStream: function(to, from) {
-    logging('DEPRECATED, reattachMediaStream will soon be removed.');
-    to.srcObject = from.srcObject;
   }
 };
 
 // Expose public methods.
 module.exports = {
   shimPeerConnection: edgeShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia'),
-  attachMediaStream: edgeShim.attachMediaStream,
-  reattachMediaStream: edgeShim.reattachMediaStream
+  shimGetUserMedia: require('./getusermedia')
 };

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -8,7 +8,6 @@
  /* eslint-env node */
 'use strict';
 
-var logging = require('../utils').log;
 var browserDetails = require('../utils').browserDetails;
 
 var firefoxShim = {
@@ -144,17 +143,6 @@ var firefoxShim = {
         })
         .then(onSucc, onErr);
     };
-  },
-
-  // Attach a media stream to an element.
-  attachMediaStream: function(element, stream) {
-    logging('DEPRECATED, attachMediaStream will soon be removed.');
-    element.srcObject = stream;
-  },
-
-  reattachMediaStream: function(to, from) {
-    logging('DEPRECATED, reattachMediaStream will soon be removed.');
-    to.srcObject = from.srcObject;
   }
 };
 
@@ -163,7 +151,5 @@ module.exports = {
   shimOnTrack: firefoxShim.shimOnTrack,
   shimSourceObject: firefoxShim.shimSourceObject,
   shimPeerConnection: firefoxShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia'),
-  attachMediaStream: firefoxShim.attachMediaStream,
-  reattachMediaStream: firefoxShim.reattachMediaStream
+  shimGetUserMedia: require('./getusermedia')
 };

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -10,10 +10,6 @@ var safariShim = {
   // TODO: DrAlex, should be here, double check against LayoutTests
   // shimOnTrack: function() { },
 
-  // TODO: DrAlex
-  // attachMediaStream: function(element, stream) { },
-  // reattachMediaStream: function(to, from) { },
-
   // TODO: once the back-end for the mac port is done, add.
   // TODO: check for webkitGTK+
   // shimPeerConnection: function() { },
@@ -28,7 +24,5 @@ module.exports = {
   shimGetUserMedia: safariShim.shimGetUserMedia
   // TODO
   // shimOnTrack: safariShim.shimOnTrack,
-  // shimPeerConnection: safariShim.shimPeerConnection,
-  // attachMediaStream: safariShim.attachMediaStream,
-  // reattachMediaStream: safariShim.reattachMediaStream
+  // shimPeerConnection: safariShim.shimPeerConnection
 };

--- a/test/test.js
+++ b/test/test.js
@@ -346,188 +346,6 @@ test('Create RTCPeerConnection', function(t) {
   });
 });
 
-test('attachMediaStream', function(t) {
-  var driver = seleniumHelpers.buildDriver();
-
-  // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
-
-    var constraints = {video: true, fake: true};
-    navigator.mediaDevices.getUserMedia(constraints)
-    .then(function(stream) {
-      window.stream = stream;
-
-      var video = document.createElement('video');
-      video.setAttribute('id', 'video');
-      video.setAttribute('autoplay', 'true');
-      // If attachMediaStream works, we should get a video
-      // at some point. This will trigger loadedmetadata.
-      video.addEventListener('loadedmetadata', function() {
-        document.body.appendChild(video);
-        callback(null);
-      });
-
-      window.adapter.browserShim.attachMediaStream(video, stream);
-    })
-    .catch(function(err) {
-      callback(err.name);
-    });
-  };
-
-  // Run test.
-  seleniumHelpers.loadTestPage(driver)
-  .then(function() {
-    t.plan(6);
-    t.pass('Page loaded');
-    return driver.executeAsyncScript(testDefinition);
-  })
-  .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
-    t.ok(!error, 'getUserMedia result:  ' + gumResult);
-    // We need to wait due to the stream can take a while to setup.
-    driver.wait(function() {
-      return driver.executeScript(
-        'return typeof window.stream !== \'undefined\'');
-    }, 3000);
-    return driver.executeScript(
-      // Firefox and Chrome have different constructor names.
-      'return window.stream.constructor.name.match(\'MediaStream\') !== null');
-  })
-  .then(function(isMediaStream) {
-    t.ok(isMediaStream, 'Stream is a MediaStream');
-    // Wait until loadededmetadata event has fired and appended video element.
-    // 5 second timeout in case the event does not fire for some reason.
-    return driver.wait(webdriver.until.elementLocated(
-      webdriver.By.id('video')), 3000);
-  })
-  .then(function(videoElement) {
-    t.pass('attachMediaStream successfully attached stream to video element');
-    videoElement.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video width is: ' + width);
-        t.ok(height > 2, 'Video height is: ' + height);
-      });
-    });
-  })
-  .then(function() {
-    t.end();
-  })
-  .then(null, function(err) {
-    if (err !== 'skip-test') {
-      t.fail(err);
-    }
-    t.end();
-  });
-});
-
-test('reattachMediaStream', function(t) {
-  var driver = seleniumHelpers.buildDriver();
-
-  // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
-
-    var constraints = {video: true, fake: true};
-    navigator.mediaDevices.getUserMedia(constraints)
-    .then(function(stream) {
-      window.stream = stream;
-
-      var video = document.createElement('video');
-      var video2 = document.createElement('video');
-      video.setAttribute('id', 'video');
-      video.setAttribute('autoplay', 'true');
-      video2.setAttribute('id', 'video2');
-      video2.setAttribute('autoplay', 'true');
-      // If attachMediaStream works, we should get a video
-      // at some point. This will trigger loadedmetadata.
-      // This reattaches to the second video which will trigger
-      // loadedmetadata there.
-      video.addEventListener('loadedmetadata', function() {
-        document.body.appendChild(video);
-        window.adapter.browserShim.reattachMediaStream(video2, video);
-      });
-      video2.addEventListener('loadedmetadata', function() {
-        document.body.appendChild(video2);
-        callback(null);
-      });
-
-      window.adapter.browserShim.attachMediaStream(video, stream);
-    })
-    .catch(function(err) {
-      callback(err.name);
-    });
-  };
-
-  // Run test.
-  seleniumHelpers.loadTestPage(driver)
-  .then(function() {
-    t.plan(9);
-    t.pass('Page loaded');
-    return driver.executeAsyncScript(testDefinition);
-  })
-  .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
-    t.ok(!error, 'getUserMedia result:  ' + gumResult);
-    driver.wait(function() {
-      // We need to wait due to the stream can take a while to setup.
-      return driver.executeScript(
-        'return typeof window.stream !== \'undefined\'');
-    }, 3000);
-    return driver.executeScript(
-      // Firefox and Chrome have different constructor names.
-      'return window.stream.constructor.name.match(\'MediaStream\') !== null');
-  })
-  .then(function(isMediaStream) {
-    t.ok(isMediaStream, 'Stream is a MediaStream');
-    // Wait until loadedmetadata event has fired and appended video element.
-    return driver.wait(webdriver.until.elementLocated(
-      webdriver.By.id('video')), 3000);
-  })
-  .then(function(videoElement) {
-    t.pass('attachMediaStream successfully attached stream to video element');
-    videoElement.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video width is: ' + width);
-        t.ok(height > 2, 'Video height is: ' + height);
-      });
-    });
-    // Wait until loadedmetadata event has fired and appended video element.
-    return driver.wait(webdriver.until.elementLocated(
-      webdriver.By.id('video2')), 3000);
-  })
-  .then(function(videoElement2) {
-    t.pass('attachMediaStream succesfully re-attached stream to video element');
-    videoElement2.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement2.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video 2 width is: ' + width);
-        t.ok(height > 2, 'Video 2 height is: ' + height);
-      });
-    });
-  })
-  .then(function() {
-    t.end();
-  })
-  .then(null, function(err) {
-    if (err !== 'skip-test') {
-      t.fail(err);
-    }
-    t.end();
-  });
-});
-
 test('Video srcObject getter/setter test', function(t) {
   var driver = seleniumHelpers.buildDriver();
 
@@ -544,7 +362,7 @@ test('Video srcObject getter/setter test', function(t) {
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       video.srcObject = stream;
-      // If attachMediaStream works, we should get a video
+      // If the srcObject shim works, we should get a video
       // at some point. This will trigger loadedmetadata.
       video.addEventListener('loadedmetadata', function() {
         document.body.appendChild(video);
@@ -610,7 +428,7 @@ test('Audio srcObject getter/setter test', function(t) {
       var audio = document.createElement('audio');
       audio.setAttribute('id', 'audio');
       audio.srcObject = stream;
-      // If attachMediaStream works, we should get a video
+      // If the srcObject shim works, we should get a video
       // at some point. This will trigger loadedmetadata.
       audio.addEventListener('loadedmetadata', function() {
         document.body.appendChild(audio);
@@ -680,7 +498,7 @@ test('srcObject set from another object', function(t) {
       video.srcObject = stream;
       video2.srcObject = video.srcObject;
 
-      // If attachMediaStream works, we should get a video
+      // If the srcObject shim works, we should get a video
       // at some point. This will trigger loadedmetadata.
       video.addEventListener('loadedmetadata', function() {
         document.body.appendChild(video);
@@ -807,7 +625,7 @@ test('Attach mediaStream directly', function(t) {
       var video = document.createElement('video');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
-      // If attachMediaStream works, we should get a video
+      // If the srcObject shim works, we should get a video
       // at some point. This will trigger loadedmetadata.
       // Firefox < 38 had issues with this, workaround removed
       // due to 38 being stable now.
@@ -2283,12 +2101,6 @@ test('Non-module logging to console still works', function(t) {
         'RTCPeerConnection is a function']);
     window.testsEqualArray.push([typeof navigator.getUserMedia, 'function',
         'getUserMedia is a function']);
-    window.testsEqualArray.push(
-      [typeof window.adapter.browserShim.attachMediaStream, 'function',
-        'attachMediaStream is a function']);
-    window.testsEqualArray.push(
-      [typeof window.adapter.browserShim.reattachMediaStream,'function',
-        'reattachMediaSteam is a function']);
     window.testsEqualArray.push([typeof window.adapter.browserDetails.browser,
         'string', 'browserDetails.browser browser is a string']);
     window.testsEqualArray.push([typeof window.adapter.browserDetails.version,


### PR DESCRIPTION
**Description**
this remove attachmediastream and reattachmediastream. When moving to 1.0 we hid them in such a ugly way that hopefully nobody uses them anyway.

This needs a major version bump. I think we should do #192 and support for the new native getUserMedia at the same time.
