### PR TITLE
remove minVersion

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -49,7 +49,7 @@ var utils = {
   /**
    * Browser detector.
    *
-   * @return {object} result containing browser, version and minVersion
+   * @return {object} result containing browser and version
    *     properties.
    */
   detectBrowser: function() {
@@ -57,7 +57,6 @@ var utils = {
     var result = {};
     result.browser = null;
     result.version = null;
-    result.minVersion = null;
 
     // Fail early if it's not a browser
     if (typeof window === 'undefined' || !window.navigator) {
@@ -70,7 +69,6 @@ var utils = {
       result.browser = 'firefox';
       result.version = this.extractVersion(navigator.userAgent,
           /Firefox\/([0-9]+)\./, 1);
-      result.minVersion = 31;
 
     // all webkit-based browsers
     } else if (navigator.webkitGetUserMedia) {
@@ -79,7 +77,6 @@ var utils = {
         result.browser = 'chrome';
         result.version = this.extractVersion(navigator.userAgent,
           /Chrom(e|ium)\/([0-9]+)\./, 2);
-        result.minVersion = 38;
 
       // Safari or unknown webkit-based
       // for the time being Safari has support for MediaStreams but not webRTC
@@ -99,7 +96,6 @@ var utils = {
           result.browser = 'safari';
           result.version = this.extractVersion(navigator.userAgent,
             /AppleWebKit\/([0-9]+)\./, 1);
-          result.minVersion = 602;
 
         // unknown webkit-based browser
         } else {
@@ -115,19 +111,11 @@ var utils = {
       result.browser = 'edge';
       result.version = this.extractVersion(navigator.userAgent,
           /Edge\/(\d+).(\d+)$/, 2);
-      result.minVersion = 10547;
 
     // Default fallthrough: not supported.
     } else {
       result.browser = 'Not a supported browser.';
       return result;
-    }
-
-    // Warn if version is less than minVersion.
-    if (result.version < result.minVersion) {
-      utils.log('Browser: ' + result.browser + ' Version: ' + result.version +
-          ' < minimum supported version: ' + result.minVersion +
-          '\n some things might not work!');
     }
 
     return result;

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ test('Browser identified', function(t) {
   // Run test.
   seleniumHelpers.loadTestPage(driver)
   .then(function() {
-    t.plan(4);
+    t.plan(3);
     t.pass('Page loaded');
     return driver.executeScript('return adapter.browserDetails.version');
   })
@@ -111,38 +111,6 @@ test('Browser identified', function(t) {
   .then(function(webrtcDetectVersion) {
     t.ok(webrtcDetectVersion, 'Browser version detected: ' +
         webrtcDetectVersion);
-    return driver.executeScript('return adapter.browserDetails.minVersion');
-  })
-  .then(function(webrtcMinimumVersion) {
-    t.ok(webrtcMinimumVersion, 'Minimum Browser version detected: ' +
-        webrtcMinimumVersion);
-    t.end();
-  })
-  .then(null, function(err) {
-    if (err !== 'skip-test') {
-      t.fail(err);
-    }
-    t.end();
-  });
-});
-
-test('Browser supported by adapter.js', function(t) {
-  var driver = seleniumHelpers.buildDriver();
-
-  // Run test.
-  seleniumHelpers.loadTestPage(driver)
-  .then(function() {
-    t.plan(2);
-    t.pass('Page loaded');
-  })
-  .then(function() {
-    return driver.executeScript(
-      'return adapter.browserDetails.version ' +
-          '>= adapter.browserDetails.minVersion');
-  })
-  .then(function(webrtcVersionIsGreaterOrEqual) {
-    t.ok(webrtcVersionIsGreaterOrEqual,
-        'Browser version supported by adapter.js');
     t.end();
   })
   .then(null, function(err) {


### PR DESCRIPTION
minVersion is not really usable right now. The original plan was to allow
rejecting old browser versions based on this. However, this doesn't work.
Suppose we reject Chrome-based things < Chrome 50. Well...
Opera is at version 38 right now and gets detected as 38. So this would
just block all Opera users! Platform detection is something the app needs to
do unfortunately unless we want to have more complicated rules here (e.g.
by doing more UA string parsing using the platform module)
