### PR TITLE
[doc] Fix npm usage help link for webrtc/samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm install webrtc-adapter
 ## Usage ##
 ##### NPM
 Copy to desired location in your src tree or use a minify/vulcanize tool (node_modules is usually not published with the code).
-See [webrtc/samples repo](https://github.com/webrtc/samples/blob/master/package.json) as an example on how you can do this.
+See [webrtc/samples repo](https://github.com/webrtc/samples/blob/gh-pages/package.json) as an example on how you can do this.
 
 #### Prebuilt releases
 ##### Web


### PR DESCRIPTION
This PR fixes the URL to the npm sample, it was pointing to the `master` branch that doesn`t exist anymore. :)
