### PR TITLE
chrome/edge interop: hardcode chrome default ssrcs

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -524,6 +524,18 @@ var edgeShim = {
             recvEncodingParameters =
                 SDPUtils.parseRtpEncodingParameters(mediaSection);
 
+            // Chrome does announce its SSRCs for recvonly streams.
+            // https://bugs.chromium.org/p/webrtc/issues/detail?id=4740
+            if (recvEncodingParameters.length === 0
+                && SDPUtils.matchPrefix(sessionpart,
+                'a=msid-semantic: WMS').length) {
+              if (kind === 'audio') {
+                recvEncodingParameters.push({ssrc: 0xfa17fa17});
+              } else if (kind === 'video') {
+                recvEncodingParameters.push({ssrc: 0x1});
+              }
+            }
+
             var mid = SDPUtils.matchPrefix(mediaSection, 'a=mid:');
             if (mid.length) {
               mid = mid[0].substr(6);


### PR DESCRIPTION
working around https://bugs.chromium.org/p/webrtc/issues/detail?id=4740
Guarded by an extra "is this chrome?", hoping that nobody else uses this ancient version of MSID.

I suspect this is causing NACKs and PLIs not to be sent/received properly which leads to pictures like [this](https://twitter.com/HCornflower/status/741706976703479812), [this](https://twitter.com/HCornflower/status/738079011750940672) and [this](https://twitter.com/HCornflower/status/736456618758574080).

Hard to tell if that actually fixes things, this was rare to begin with.
