### PR TITLE
edge: end-of-candidates can be at session level

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -546,7 +546,7 @@ var edgeShim = {
             }
 
             var isComplete = SDPUtils.matchPrefix(mediaSection,
-                'a=end-of-candidates').length > 0;
+                'a=end-of-candidates', sessionpart).length > 0;
             var cands = SDPUtils.matchPrefix(mediaSection, 'a=candidate:')
                 .map(function(cand) {
                   return SDPUtils.parseCandidate(cand);


### PR DESCRIPTION
a=end-of-candidates is currently only parsed at m-line level but it can be a session-level attribute, 
see https://tools.ietf.org/html/draft-ietf-mmusic-trickle-ice-sip-04#section-8.2

kudos to @freeswitch for pointing this out
