### PR TITLE
Fix bower handling

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,4 +6,5 @@ validation-report.json
 validation-status.json
 npm-debug.log
 *~
+release/
 

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ validation-report.json
 validation-status.json
 npm-debug.log
 *~
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,13 +61,29 @@ module.exports = function(grunt) {
       },
       target: ['src/**/*.js', 'test/*.js']
     },
+    copy: {
+      build: {
+        cwd: '.',
+        files: [
+          {src: [
+            'out/'
+            ],
+            dest: 'release',
+            nonull: true,
+            expand: true
+          }
+        ]
+      }
+    },
   });
 
   grunt.loadNpmTasks('grunt-githooks');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-contrib-copy');
 
   grunt.registerTask('default', ['eslint', 'browserify']);
   grunt.registerTask('lint', ['eslint']);
   grunt.registerTask('build', ['browserify']);
+  grunt.registerTask('copyForPublish', ['copy']);
 };

--- a/bower.json
+++ b/bower.json
@@ -1,9 +1,9 @@
 {
-  "name": "webrtc-adapter",
-  "version": "1.0.5",
+  "name": "webrtc-adapter-testingPublish",
+  "version": "2.0.0",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
-  "main": "./src/js/adapter_core.js",
+  "main": "./release/adapter.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
-  "name": "webrtc-adapter-testingPublish",
-  "version": "2.0.0",
+  "name": "webrtc-adapter",
+  "version": "1.4.0",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
   "main": "./release/adapter.js",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "preversion": "git stash && git checkout master && git pull && npm test | faucet && git checkout -B bumpVersion",
     "version": "grunt build",
-    "postversion": "git push --force --set-upstream origin bumpVersion --follow-tags && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir -p adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
+    "postversion": "grunt copyForPublish && git add release/* && export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git commit -m `$GITTAG` && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir -p adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
     "test": "grunt && node test/run-tests.js"
   },
@@ -31,6 +31,8 @@
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": ">=0.1.9",
+    "grunt-contrib-clean": "^1.0.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-eslint": "^17.2.0",
     "grunt-githooks": "^0.3.1",
     "selenium-webdriver": "^2.52.0",

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var SDPUtils = require('sdp');
+var browserDetails = require('../utils').browserDetails;
 
 var edgeShim = {
   shimPeerConnection: function() {
@@ -102,9 +103,11 @@ var edgeShim = {
               urls = [urls];
             }
             urls = urls.filter(function(url) {
-              return url.indexOf('turn:') === 0 &&
+              return (url.indexOf('turn:') === 0 &&
                   url.indexOf('transport=udp') !== -1 &&
-                  url.indexOf('turn:[') === -1;
+                  url.indexOf('turn:[') === -1) ||
+                  (url.indexOf('stun:') === 0 &&
+                    browserDetails.version >= 14393);
             })[0];
             return !!urls;
           }


### PR DESCRIPTION
**Description**
When issuing the command `npm version minor -m 'bump to %s'`it will make sure the current tree is clean by stashing any untracked changes, check out master, run all tests and create a bumpVersion branch overwriting any existing branch and history.

Then it will build the adapter artifacts, copy them to release/ and add them and the git tag version to a commit and force push this to github. Then checkout gh-pages, copy all the artifacts to it and named the according to the git tag version, copy adapter.js to root and symlink to adapter-latest.js. Add all these files to a commit and push to github and finally checkout master again.

**Purpose**
Lots of this logic already existed but the release/ folder is new, this will check in the latest release of adapter.js to the master branch and thus allow bower users to use the semver versioning properly when fetching adapter.js.
