### PR TITLE
Bower version is deprecated

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "webrtc-adapter",
-  "version": "2.0.2",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
   "main": "./release/adapter.js",


### PR DESCRIPTION
**Description**

The Bower version attribute is deprecated ([source](https://github.com/bower/spec/blob/master/json.md#version)) and Bower will make use of `git` or `svn` tags. Since "webrtc-adapter" has proper [release versions](https://github.com/webrtc/adapter/releases), it is recommended to drop the `version` property in `bower.json`.

Less maintenance. Yay!! :speedboat: :pineapple:

**Purpose**

Bower version is deprecated and having that property can lead to version mismatch problems like this one:

![screenshot](https://cloud.githubusercontent.com/assets/469989/18001761/c1fbfc9a-6b84-11e6-95f9-24089b051cad.png)
