### PR TITLE
re-enable firefox tests with geckodriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,17 +12,14 @@ env:
     - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=nightly
     - BROWSER=firefox BVER=esr
-    - BROWSER=MicrosoftEdge BVER=stable
 
 matrix:
   fast_finish: true
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
-    - env: BROWSER=firefox BVER=stable
-    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
-    - env: BROWSER=MicrosoftEdge BVER=stable
+    - env: BROWSER=firefox BVER=esr
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "chromedriver": "^2.16.0",
     "eslint-config-webrtc": "^1.0.0",
     "faucet": "0.0.1",
+    "geckodriver": "^1.1.3",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": ">=0.1.9",
@@ -35,7 +36,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-eslint": "^17.2.0",
     "grunt-githooks": "^0.3.1",
-    "selenium-webdriver": "^2.52.0",
+    "selenium-webdriver": "^3.0.0-beta-3",
     "tape": "^4.0.0",
     "travis-multirunner": "^3.0.1"
   }

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -79,7 +79,7 @@ function buildDriver() {
   }
 
   // Only enable this for Chrome >= 49.
-  if (process.env.BROWSER === 'chrome' && getBrowserVersion >= '49') {
+  if (process.env.BROWSER === 'chrome' && getBrowserVersion >= 49) {
     chromeOptions.addArguments('--enable-experimental-web-platform-features');
   }
 
@@ -98,6 +98,8 @@ function buildDriver() {
       throw new Error('MicrosoftEdge is only supported on Windows or via ' +
           'a selenium server');
     }
+  } else if (process.env.BROWSER === 'firefox' && getBrowserVersion >= 47) {
+    sharedDriver.getCapabilities().set('marionette', true);
   }
 
   sharedDriver = sharedDriver.build();

--- a/test/test.js
+++ b/test/test.js
@@ -612,7 +612,7 @@ test('Attach mediaStream directly', function(t) {
   // Run test.
   seleniumHelpers.loadTestPage(driver)
   .then(function() {
-    t.plan(6);
+    t.plan(4);
     t.pass('Page loaded');
     return driver.executeAsyncScript(testDefinition);
   })
@@ -635,20 +635,14 @@ test('Attach mediaStream directly', function(t) {
     return driver.wait(webdriver.until.elementLocated(
       webdriver.By.id('video')), 3000);
   })
-  .then(function(videoElement) {
-    t.pass('Stream attached directly succesfully to a video element');
-    videoElement.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video width is: ' + width);
-        t.ok(height > 2, 'Video height is: ' + height);
-      });
-    });
+  .then(function() {
+    return driver.wait(function() {
+      return driver.executeScript(
+          'return document.getElementById("video").readyState === 4');
+    }, 3000);
   })
   .then(function() {
+    t.pass('Stream attached directly succesfully to a video element');
     t.end();
   })
   .then(null, function(err) {
@@ -700,7 +694,7 @@ test('Re-attaching mediaStream directly', function(t) {
   // Run test.
   seleniumHelpers.loadTestPage(driver)
   .then(function() {
-    t.plan(9);
+    t.plan(5);
     t.pass('Page loaded');
     return driver.executeAsyncScript(testDefinition);
   })
@@ -726,36 +720,26 @@ test('Re-attaching mediaStream directly', function(t) {
       webdriver.By.id('video')), 3000);
   })
   .then(function(videoElement) {
+    return driver.wait(function() {
+      return driver.executeScript(
+          'return document.querySelector("video").readyState === 4');
+    }, 3000);
+  })
+  .then(function() {
     t.pass('Stream attached directly succesfully to a video element');
-    videoElement.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video width is: ' + width);
-        t.ok(height > 2, 'Video height is: ' + height);
-      });
-    });
     // Wait until loadedmetadata event has fired and appended video element.
     // 5 second timeout in case the event does not fire for some reason.
     return driver.wait(webdriver.until.elementLocated(
       webdriver.By.id('video2')), 3000);
   })
-  .then(function(videoElement2) {
-    t.pass('Stream re-attached directly succesfully to a video element');
-    videoElement2.getAttribute('videoWidth')
-    .then(function(width) {
-      videoElement2.getAttribute('videoHeight')
-      .then(function(height) {
-        // Chrome sets the stream dimensions to 2x2 if something is wrong
-        // with the stream/frames from the camera.
-        t.ok(width > 2, 'Video 2 width is: ' + width);
-        t.ok(height > 2, 'Video 2 height is: ' + height);
-      });
-    });
+  .then(function() {
+    return driver.wait(function() {
+      return driver.executeScript(
+          'return document.getElementById("video2").readyState === 4');
+    }, 3000);
   })
   .then(function() {
+    t.pass('Stream re-attached directly succesfully to a video element');
     t.end();
   })
   .then(null, function(err) {


### PR DESCRIPTION
**Purpose**

this re-enables tests in Firefox 47+ using geckodriver
