### PR TITLE
Unbreak facingMode polyfill on Chrome 53-56 (#370)

### DIFF
--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -72,7 +72,7 @@ module.exports = function() {
       // Shim facingMode for mobile, where it defaults to "user".
       var face = constraints.video.facingMode;
       face = face && ((typeof face === 'object') ? face : {ideal: face});
-      var getSupportedFacingModeLies = browserDetails.version < 57;
+      var getSupportedFacingModeLies = browserDetails.version < 59;
 
       if ((face && (face.exact === 'user' || face.exact === 'environment' ||
                     face.ideal === 'user' || face.ideal === 'environment')) &&

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -13,8 +13,7 @@ var browserDetails = require('../utils.js').browserDetails;
 // Expose public methods.
 module.exports = function() {
   var constraintsToChrome_ = function(c) {
-    if (browserDetails.version >= 53 ||
-        typeof c !== 'object' || c.mandatory || c.optional) {
+    if (typeof c !== 'object' || c.mandatory || c.optional) {
       return c;
     }
     var cc = {};

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -8,11 +8,13 @@
  /* eslint-env node */
 'use strict';
 var logging = require('../utils.js').log;
+var browserDetails = require('../utils.js').browserDetails;
 
 // Expose public methods.
 module.exports = function() {
   var constraintsToChrome_ = function(c) {
-    if (typeof c !== 'object' || c.mandatory || c.optional) {
+    if (browserDetails.version >= 53 ||
+        typeof c !== 'object' || c.mandatory || c.optional) {
       return c;
     }
     var cc = {};
@@ -71,11 +73,13 @@ module.exports = function() {
       // Shim facingMode for mobile, where it defaults to "user".
       var face = constraints.video.facingMode;
       face = face && ((typeof face === 'object') ? face : {ideal: face});
+      var getSupportedFacingModeLies = browserDetails.version < 57;
 
       if ((face && (face.exact === 'user' || face.exact === 'environment' ||
                     face.ideal === 'user' || face.ideal === 'environment')) &&
           !(navigator.mediaDevices.getSupportedConstraints &&
-            navigator.mediaDevices.getSupportedConstraints().facingMode)) {
+            navigator.mediaDevices.getSupportedConstraints().facingMode &&
+            !getSupportedFacingModeLies)) {
         delete constraints.video.facingMode;
         if (face.exact === 'environment' || face.ideal === 'environment') {
           // Look for "back" in label, or use last cam (typically back cam).
@@ -149,6 +153,12 @@ module.exports = function() {
             }));
           });
         });
+      },
+      getSupportedConstraints: function() {
+        return {
+          deviceId: true, echoCancellation: true, facingMode: true,
+          frameRate: true, height: true, width: true
+        };
       }
     };
   }


### PR DESCRIPTION
**Description**
Ignore `navigator.mediaDevices.getSupportedConstraints().facingMode` on 53-56 because it lies.

**Purpose**

Fix https://github.com/webrtc/adapter/issues/370.
