### PR TITLE
edge: add profile level asymmetry flag to H264

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -921,6 +921,14 @@ var edgeShim = {
             function(codec) {
               return codec.name !== 'rtx';
             });
+        localCapabilities.codecs.forEach(function(codec) {
+          // work around https://bugs.chromium.org/p/webrtc/issues/detail?id=6552
+          // by adding level-asymmetry-allowed=1
+          if (codec.name === 'H264' &&
+              codec.parameters['level-asymmetry-allowed'] === undefined) {
+            codec.parameters['level-asymmetry-allowed'] = '1';
+          }
+        });
 
         var rtpSender;
         var rtpReceiver;


### PR DESCRIPTION
this currently breaks interop between Edge and Chrome M56, see
https://bugs.chromium.org/p/webrtc/issues/detail?id=6552

cc @alvestrand @magjed
