### PR TITLE
add support for addIceCandidate(undefined)

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -239,11 +239,11 @@ var chromeShim = {
           };
         });
 
-    // support for addIceCandidate(null)
+    // support for addIceCandidate(null or undefined)
     var nativeAddIceCandidate =
         RTCPeerConnection.prototype.addIceCandidate;
     RTCPeerConnection.prototype.addIceCandidate = function() {
-      if (arguments[0] === null) {
+      if (!arguments[0]) {
         if (arguments[1]) {
           arguments[1].apply(null);
         }

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1017,7 +1017,7 @@ var edgeShim = {
     };
 
     window.RTCPeerConnection.prototype.addIceCandidate = function(candidate) {
-      if (candidate === null) {
+      if (!candidate) {
         this.transceivers.forEach(function(transceiver) {
           transceiver.iceTransport.addRemoteCandidate({});
         });

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -117,11 +117,11 @@ var firefoxShim = {
           };
         });
 
-    // support for addIceCandidate(null)
+    // support for addIceCandidate(null or undefined)
     var nativeAddIceCandidate =
         RTCPeerConnection.prototype.addIceCandidate;
     RTCPeerConnection.prototype.addIceCandidate = function() {
-      if (arguments[0] === null) {
+      if (!arguments[0]) {
         if (arguments[1]) {
           arguments[1].apply(null);
         }

--- a/test/test.js
+++ b/test/test.js
@@ -1464,6 +1464,8 @@ test('addIceCandidate with null', function(t) {
 
     var pc1 = new RTCPeerConnection(null);
     pc1.addIceCandidate(null)
+    // callback is called with either the empty result
+    // of the .then or the error from .catch.
     .then(callback)
     .catch(callback);
   };
@@ -1475,6 +1477,37 @@ test('addIceCandidate with null', function(t) {
   })
   .then(function(err) {
     t.ok(err === null, 'addIceCandidate(null) resolves');
+    t.end();
+  })
+  .then(null, function(err) {
+    if (err !== 'skip-test') {
+      t.fail(err);
+    }
+    t.end();
+  });
+});
+
+test('addIceCandidate with undefined', function(t) {
+  var driver = seleniumHelpers.buildDriver();
+
+  var testDefinition = function() {
+    var callback = arguments[arguments.length - 1];
+
+    var pc1 = new RTCPeerConnection(null);
+    pc1.addIceCandidate(undefined)
+    // callback is called with either the empty result
+    // of the .then or the error from .catch.
+    .then(callback)
+    .catch(callback);
+  };
+  // Run test.
+  seleniumHelpers.loadTestPage(driver)
+  .then(function() {
+    t.pass('Page loaded');
+    return driver.executeAsyncScript(testDefinition);
+  })
+  .then(function(err) {
+    t.ok(err === null, 'addIceCandidate(undefined) resolves');
     t.end();
   })
   .then(null, function(err) {


### PR DESCRIPTION
this adds support for addIceCandidate(undefined) in addition to addIceCandidate(null)

This would allow writing single-page samples and tests that just feed the event.candidate from onicecandidate into addIceCandidate which I think is the direction we want to go.

While the spec currently seems to be going into a different direction wrt to the exact format this is no worse than addIceCandidate(null)

@alvestrand 