### PR TITLE
Edge: improve common capability determination

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -206,8 +206,10 @@ var edgeShim = {
             for (var i = 0; i < remoteCapabilities.codecs.length; i++) {
               var rCodec = remoteCapabilities.codecs[i];
               if (lCodec.name.toLowerCase() === rCodec.name.toLowerCase() &&
-                  lCodec.clockRate === rCodec.clockRate &&
-                  lCodec.numChannels === rCodec.numChannels) {
+                  lCodec.clockRate === rCodec.clockRate) {
+                // number of channels is the highest common number of channels
+                rCodec.numChannels = Math.min(lCodec.numChannels,
+                    rCodec.numChannels);
                 // push rCodec so we reply with offerer payload type
                 commonCapabilities.codecs.push(rCodec);
 


### PR DESCRIPTION
This improves the determination of common capabilities
such that two codecs will be considered equal even if
the number of channels does not match. In that case,
the lower number will be used.