### PR TITLE
Edge: add enabled event to MediaStreamTrack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- 4.6
+- 6
 
 env:
   matrix:


### PR DESCRIPTION
this adds an 'enabled' event to MediaStreamTrack which
is emitted whenever the tracks enabled property is changed.

This allows a clone of this stream/track (which is currently done in
PC.addStream because of bugs (which got fixed recently)) to mirror the state of the original track.
This is required to allow muting a source track and then muting this
track in all peerconnections.