### PR TITLE
update chrome shim

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -144,7 +144,13 @@ var chromeShim = {
           var standardStats = {
             id: report.id,
             timestamp: report.timestamp,
-            type: report.type
+            type: {
+              inboundrtp: 'inbound-rtp',
+              outboundrtp: 'outbound-rtp',
+              candidatepair: 'candidate-pair',
+              localcandidate: 'local-candidate',
+              remotecandidate: 'remote-candidate'
+            }[report.type] || report.type
           };
           report.names().forEach(function(name) {
             standardStats[name] = report.stat(name);

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -133,6 +133,11 @@ var chromeShim = {
         return origGetStats.apply(this, arguments);
       }
 
+      // When spec-style getStats is supported, return those.
+      if (origGetStats.length === 0) {
+        return origGetStats.apply(this, arguments);
+      }
+
       var fixChromeStats_ = function(response) {
         var standardReport = {};
         var reports = response.result();

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -112,7 +112,7 @@ var chromeShim = {
       };
       window.RTCPeerConnection.prototype = webkitRTCPeerConnection.prototype;
       // wrap static methods. Currently just generateCertificate.
-      if (!RTCPeerConnection.generateCertificate) {
+      if (webkitRTCPeerConnection.generateCertificate) {
         Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
           get: function() {
             return webkitRTCPeerConnection.generateCertificate;

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -162,15 +162,10 @@ var chromeShim = {
       };
 
       // shim getStats with maplike support
-      var makeMapStats = function(stats, legacyStats) {
-        var map = new Map(Object.keys(stats).map(function(key) {
+      var makeMapStats = function(stats) {
+        return new Map(Object.keys(stats).map(function(key) {
           return[key, stats[key]];
         }));
-        legacyStats = legacyStats || stats;
-        Object.keys(legacyStats).forEach(function(key) {
-          map[key] = legacyStats[key];
-        });
-        return map;
       };
 
       if (arguments.length >= 2) {
@@ -184,19 +179,10 @@ var chromeShim = {
 
       // promise-support
       return new Promise(function(resolve, reject) {
-        if (args.length === 1 && typeof selector === 'object') {
-          origGetStats.apply(self, [
-            function(response) {
-              resolve(makeMapStats(fixChromeStats_(response)));
-            }, reject]);
-        } else {
-          // Preserve legacy chrome stats only on legacy access of stats obj
-          origGetStats.apply(self, [
-            function(response) {
-              resolve(makeMapStats(fixChromeStats_(response),
-                  response.result()));
-            }, reject]);
-        }
+        origGetStats.apply(self, [
+          function(response) {
+            resolve(makeMapStats(fixChromeStats_(response)));
+          }, reject]);
       }).then(successCallback, errorCallback);
     };
 

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -100,83 +100,84 @@ var chromeShim = {
     window.RTCPeerConnection = function(pcConfig, pcConstraints) {
       // Translate iceTransportPolicy to iceTransports,
       // see https://code.google.com/p/webrtc/issues/detail?id=4869
+      // this was fixed in M56 along with unprefixing RTCPeerConnection.
       logging('PeerConnection');
       if (pcConfig && pcConfig.iceTransportPolicy) {
         pcConfig.iceTransports = pcConfig.iceTransportPolicy;
       }
 
-      var pc = new webkitRTCPeerConnection(pcConfig, pcConstraints);
-      var origGetStats = pc.getStats.bind(pc);
-      pc.getStats = function(selector, successCallback, errorCallback) {
-        var self = this;
-        var args = arguments;
-
-        // If selector is a function then we are in the old style stats so just
-        // pass back the original getStats format to avoid breaking old users.
-        if (arguments.length > 0 && typeof selector === 'function') {
-          return origGetStats(selector, successCallback);
-        }
-
-        var fixChromeStats_ = function(response) {
-          var standardReport = {};
-          var reports = response.result();
-          reports.forEach(function(report) {
-            var standardStats = {
-              id: report.id,
-              timestamp: report.timestamp,
-              type: report.type
-            };
-            report.names().forEach(function(name) {
-              standardStats[name] = report.stat(name);
-            });
-            standardReport[standardStats.id] = standardStats;
-          });
-
-          return standardReport;
-        };
-
-        // shim getStats with maplike support
-        var makeMapStats = function(stats, legacyStats) {
-          var map = new Map(Object.keys(stats).map(function(key) {
-            return[key, stats[key]];
-          }));
-          legacyStats = legacyStats || stats;
-          Object.keys(legacyStats).forEach(function(key) {
-            map[key] = legacyStats[key];
-          });
-          return map;
-        };
-
-        if (arguments.length >= 2) {
-          var successCallbackWrapper_ = function(response) {
-            args[1](makeMapStats(fixChromeStats_(response)));
-          };
-
-          return origGetStats.apply(this, [successCallbackWrapper_,
-              arguments[0]]);
-        }
-
-        // promise-support
-        return new Promise(function(resolve, reject) {
-          if (args.length === 1 && typeof selector === 'object') {
-            origGetStats.apply(self, [
-              function(response) {
-                resolve(makeMapStats(fixChromeStats_(response)));
-              }, reject]);
-          } else {
-            // Preserve legacy chrome stats only on legacy access of stats obj
-            origGetStats.apply(self, [
-              function(response) {
-                resolve(makeMapStats(fixChromeStats_(response),
-                    response.result()));
-              }, reject]);
-          }
-        }).then(successCallback, errorCallback);
-      };
-
-      return pc;
+      return new webkitRTCPeerConnection(pcConfig, pcConstraints);
     };
     window.RTCPeerConnection.prototype = webkitRTCPeerConnection.prototype;
+
+    var origGetStats = webkitRTCPeerConnection.prototype.getStats;
+    webkitRTCPeerConnection.prototype.getStats = function(selector,
+        successCallback, errorCallback) {
+      var self = this;
+      var args = arguments;
+
+      // If selector is a function then we are in the old style stats so just
+      // pass back the original getStats format to avoid breaking old users.
+      if (arguments.length > 0 && typeof selector === 'function') {
+        return origGetStats.apply(this, arguments);
+      }
+
+      var fixChromeStats_ = function(response) {
+        var standardReport = {};
+        var reports = response.result();
+        reports.forEach(function(report) {
+          var standardStats = {
+            id: report.id,
+            timestamp: report.timestamp,
+            type: report.type
+          };
+          report.names().forEach(function(name) {
+            standardStats[name] = report.stat(name);
+          });
+          standardReport[standardStats.id] = standardStats;
+        });
+
+        return standardReport;
+      };
+
+      // shim getStats with maplike support
+      var makeMapStats = function(stats, legacyStats) {
+        var map = new Map(Object.keys(stats).map(function(key) {
+          return[key, stats[key]];
+        }));
+        legacyStats = legacyStats || stats;
+        Object.keys(legacyStats).forEach(function(key) {
+          map[key] = legacyStats[key];
+        });
+        return map;
+      };
+
+      if (arguments.length >= 2) {
+        var successCallbackWrapper_ = function(response) {
+          args[1](makeMapStats(fixChromeStats_(response)));
+        };
+
+        return origGetStats.apply(this, [successCallbackWrapper_,
+            arguments[0]]);
+      }
+
+      // promise-support
+      return new Promise(function(resolve, reject) {
+        if (args.length === 1 && typeof selector === 'object') {
+          origGetStats.apply(self, [
+            function(response) {
+              resolve(makeMapStats(fixChromeStats_(response)));
+            }, reject]);
+        } else {
+          // Preserve legacy chrome stats only on legacy access of stats obj
+          origGetStats.apply(self, [
+            function(response) {
+              resolve(makeMapStats(fixChromeStats_(response),
+                  response.result()));
+            }, reject]);
+        }
+      }).then(successCallback, errorCallback);
+    };
 
     // wrap static methods. Currently just generateCertificate.
     if (webkitRTCPeerConnection.generateCertificate) {

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -97,7 +97,8 @@ var chromeShim = {
 
   shimPeerConnection: function() {
     // The RTCPeerConnection object.
-    if (!window.RTCPeerConnection) {
+    var unprefixedRTCPeerConnection = !!window.RTCPeerConnection;
+    if (!unprefixedRTCPeerConnection) {
       window.RTCPeerConnection = function(pcConfig, pcConstraints) {
         // Translate iceTransportPolicy to iceTransports,
         // see https://code.google.com/p/webrtc/issues/detail?id=4869
@@ -189,45 +190,47 @@ var chromeShim = {
       }).then(successCallback, errorCallback);
     };
 
-    ['createOffer', 'createAnswer'].forEach(function(method) {
-      var nativeMethod = RTCPeerConnection.prototype[method];
-      RTCPeerConnection.prototype[method] = function() {
-        var self = this;
-        if (arguments.length < 1 || (arguments.length === 1 &&
-            typeof arguments[0] === 'object')) {
-          var opts = arguments.length === 1 ? arguments[0] : undefined;
-          return new Promise(function(resolve, reject) {
-            nativeMethod.apply(self, [resolve, reject, opts]);
-          });
-        }
-        return nativeMethod.apply(this, arguments);
-      };
-    });
+    if (!unprefixedRTCPeerConnection) {
+      ['createOffer', 'createAnswer'].forEach(function(method) {
+        var nativeMethod = RTCPeerConnection.prototype[method];
+        RTCPeerConnection.prototype[method] = function() {
+          var self = this;
+          if (arguments.length < 1 || (arguments.length === 1 &&
+              typeof arguments[0] === 'object')) {
+            var opts = arguments.length === 1 ? arguments[0] : undefined;
+            return new Promise(function(resolve, reject) {
+              nativeMethod.apply(self, [resolve, reject, opts]);
+            });
+          }
+          return nativeMethod.apply(this, arguments);
+        };
+      });
 
-    // add promise support -- natively available in Chrome 51
-    if (browserDetails.version < 51) {
-      ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
-          .forEach(function(method) {
-            var nativeMethod = RTCPeerConnection.prototype[method];
-            RTCPeerConnection.prototype[method] = function() {
-              var args = arguments;
-              var self = this;
-              var promise = new Promise(function(resolve, reject) {
-                nativeMethod.apply(self, [args[0], resolve, reject]);
-              });
-              if (args.length < 2) {
-                return promise;
-              }
-              return promise.then(function() {
-                args[1].apply(null, []);
-              },
-              function(err) {
-                if (args.length >= 3) {
-                  args[2].apply(null, [err]);
+      // add promise support -- natively available in Chrome 51
+      if (browserDetails.version < 51) {
+        ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
+            .forEach(function(method) {
+              var nativeMethod = RTCPeerConnection.prototype[method];
+              RTCPeerConnection.prototype[method] = function() {
+                var args = arguments;
+                var self = this;
+                var promise = new Promise(function(resolve, reject) {
+                  nativeMethod.apply(self, [args[0], resolve, reject]);
+                });
+                if (args.length < 2) {
+                  return promise;
                 }
-              });
-            };
-          });
+                return promise.then(function() {
+                  args[1].apply(null, []);
+                },
+                function(err) {
+                  if (args.length >= 3) {
+                    args[2].apply(null, [err]);
+                  }
+                });
+              };
+            });
+      }
     }
 
     // shim implicit creation of RTCSessionDescription/RTCIceCandidate


### PR DESCRIPTION
this updates the chrome shim to no longer override the unprefixed RTCPeerConnection and don't attempt to shim promises if they're natively available (on the unprefixed connection)

If we do a major version bump soon i'd merge it then