### PR TITLE
edge: change getStats

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1100,12 +1100,23 @@ var edgeShim = {
       });
       var cb = arguments.length > 1 && typeof arguments[1] === 'function' &&
           arguments[1];
+      var fixStatsType = function(stat) {
+        stat.type = {
+          inboundrtp: 'inbound-rtp',
+          outboundrtp: 'outbound-rtp',
+          candidatepair: 'candidate-pair',
+          localcandidate: 'local-candidate',
+          remotecandidate: 'remote-candidate'
+        }[stat.type] || stat.type;
+        return stat;
+      };
       return new Promise(function(resolve) {
         // shim getStats with maplike support
         var results = new Map();
         Promise.all(promises).then(function(res) {
           res.forEach(function(result) {
             Object.keys(result).forEach(function(id) {
+              result[id].type = fixStatsType(result[id]);
               results.set(id, result[id]);
               results[id] = result[id];
             });

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1118,7 +1118,6 @@ var edgeShim = {
             Object.keys(result).forEach(function(id) {
               result[id].type = fixStatsType(result[id]);
               results.set(id, result[id]);
-              results[id] = result[id];
             });
           });
           if (cb) {


### PR DESCRIPTION
while we're breaking getStats i thought it might be nice to do the same for Edge as well.
This adds hyphens to the stats types and removes the map-object hybrid (h/t @jan-ivar)