### PR TITLE
Do not set remote candidates twice

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -619,7 +619,7 @@ var edgeShim = {
                 dtlsTransport: self.transceivers[0].dtlsTransport
               } : self._createIceAndDtlsTransports(mid, sdpMLineIndex);
 
-              if (isComplete) {
+              if (isComplete && (!self.usingBundle || sdpMLineIndex === 0)) {
                 transports.iceTransport.setRemoteCandidates(cands);
               }
 


### PR DESCRIPTION
**Description**
Avoid setting candidates twice (IllegalStateException) when the remote offer includes the candidates and end-of-candidates flag.

**Purpose**

Add support for remote offers using bundle and including all the candidates in the sDP.