### PR TITLE
Add node 6 under engines in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "sdp": "^1.0.0"
   },
   "engines": {
-    "npm": "^3.10.0"
+    "npm": "^3.10.0",
+    "node": "^6.0.0"
   },
   "devDependencies": {
     "chromedriver": "^2.16.0",


### PR DESCRIPTION
**Description**
Add node v 6.0.0 to engines

**Purpose**
Highlight that at least node 6 is required for this repo (due to webdriver)
