### PR TITLE
Avoid IllegalState when adding empty candidate twice for bundle PeerConnection

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1019,9 +1019,12 @@ var edgeShim = {
 
     window.RTCPeerConnection.prototype.addIceCandidate = function(candidate) {
       if (!candidate) {
-        this.transceivers.forEach(function(transceiver) {
-          transceiver.iceTransport.addRemoteCandidate({});
-        });
+        for (var i = 0; i < this.transceivers.length; i++) {
+          transceivers[i].iceTransport.addRemoteCandidate({});
+          if (this.usingBundle) {
+            return;
+          }
+        }
       } else {
         var mLineIndex = candidate.sdpMLineIndex;
         if (candidate.sdpMid) {

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1019,8 +1019,8 @@ var edgeShim = {
 
     window.RTCPeerConnection.prototype.addIceCandidate = function(candidate) {
       if (!candidate) {
-        for (var i = 0; i < this.transceivers.length; i++) {
-          transceivers[i].iceTransport.addRemoteCandidate({});
+        for (var j = 0; j < this.transceivers.length; j++) {
+          this.transceivers[j].iceTransport.addRemoteCandidate({});
           if (this.usingBundle) {
             return;
           }


### PR DESCRIPTION
**Description**
Adding the empty candidate ({}) twice to the same iceTransport raises an IllegalState exception in Edge.

**Purpose**

