### PR TITLE
chrome: only hyphenate what is required

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -145,9 +145,6 @@ var chromeShim = {
             id: report.id,
             timestamp: report.timestamp,
             type: {
-              inboundrtp: 'inbound-rtp',
-              outboundrtp: 'outbound-rtp',
-              candidatepair: 'candidate-pair',
               localcandidate: 'local-candidate',
               remotecandidate: 'remote-candidate'
             }[report.type] || report.type


### PR DESCRIPTION
only hyphenate localcandidate and remotecandidate since those
are the only almost-spec stats chrome returns.