### PR TITLE
Limit spec-hyphens in type names to promise getStats and <FF53.

### DIFF
--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -161,8 +161,8 @@ var firefoxShim = {
             stats.forEach(function(stat) {
               stat.type = modernStatsTypes[stat.type] || stat.type;
             });
-            return stats;
           }
+          return stats;
         })
         .then(onSucc, onErr);
     };


### PR DESCRIPTION
**Description**
Follow-up to https://github.com/webrtc/adapter/pull/392 now that [bug 1322503](https://bugzil.la/1322503) has landed.

**Purpose**
Limit spec hyphens to promise version of getStats and to FF versions <53.