### PR TITLE
chrome: restrict new getStats

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -132,9 +132,11 @@ var chromeShim = {
         return origGetStats.apply(this, arguments);
       }
 
-      // When spec-style getStats is supported, return those.
-      if (origGetStats.length === 0) {
-        return origGetStats.apply(this, arguments);
+      // When spec-style getStats is supported, return those when called with
+      // either no arguments or the selector argument is null.
+      if (origGetStats.length === 0 && (arguments.length === 0 ||
+          typeof arguments[0] !== 'function')) {
+        return origGetStats.apply(this, []);
       }
 
       var fixChromeStats_ = function(response) {


### PR DESCRIPTION
this will only call the new getStats when there are no arguments
supplied or when the selector argument is null.

Implements @henbos's suggestion in  https://github.com/webrtc/samples/issues/863#issuecomment-275436014
