### PR TITLE
Don't shim createObjectURL on old browsers wo/srcObject to avoid infinite recursion.

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -46,8 +46,8 @@
 
       chromeShim.shimGetUserMedia();
       chromeShim.shimMediaStream();
-      chromeShim.shimSourceObject();
       utils.shimCreateObjectURL();
+      chromeShim.shimSourceObject();
       chromeShim.shimPeerConnection();
       chromeShim.shimOnTrack();
       break;

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -72,7 +72,7 @@ var chromeShim = {
 
             if (!stream) {
               this.src = '';
-              return;
+              return undefined;
             }
             this.src = URL.createObjectURL(stream);
             // We need to recreate the blob url when a track is added or

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -121,7 +121,7 @@ var utils = {
     return result;
   },
 
-  // shimCreateObjectURL must be called before shimSourceObject to avoid loop!
+  // shimCreateObjectURL must be called before shimSourceObject to avoid loop.
 
   shimCreateObjectURL: function() {
     if (!(typeof window === 'object' && window.HTMLMediaElement &&

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -121,7 +121,15 @@ var utils = {
     return result;
   },
 
+  // shimCreateObjectURL must be called before shimSourceObject to avoid loop!
+
   shimCreateObjectURL: function() {
+    if (!(typeof window === 'object' && window.HTMLMediaElement &&
+          'srcObject' in window.HTMLMediaElement.prototype)) {
+      // Only shim CreateObjectURL using srcObject if srcObject exists.
+      return;
+    }
+
     var nativeCreateObjectURL = URL.createObjectURL.bind(URL);
     var nativeRevokeObjectURL = URL.revokeObjectURL.bind(URL);
     var streams = new Map(), newId = 0;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -127,7 +127,7 @@ var utils = {
     if (!(typeof window === 'object' && window.HTMLMediaElement &&
           'srcObject' in window.HTMLMediaElement.prototype)) {
       // Only shim CreateObjectURL using srcObject if srcObject exists.
-      return;
+      return undefined;
     }
 
     var nativeCreateObjectURL = URL.createObjectURL.bind(URL);


### PR DESCRIPTION
**Description**
Fix for https://github.com/webrtc/adapter/pull/411#issuecomment-275085135.

**Purpose**
Oops.