### PR TITLE
travis: allow firefox beta to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
     - BROWSER=chrome  BVER=beta
     - BROWSER=chrome  BVER=unstable
     - BROWSER=firefox BVER=stable
-    - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=nightly
     - BROWSER=firefox BVER=esr
 
@@ -18,6 +17,7 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
+    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
     - env: BROWSER=firefox BVER=esr
 


### PR DESCRIPTION
since Firefox 52 became beta our travis builds have been failing.
This allows failure there.