### PR TITLE
core: remove opera case

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -34,7 +34,6 @@
 
   // Shim browser if found.
   switch (browserDetails.browser) {
-    case 'opera': // fallthrough as it uses chrome shims
     case 'chrome':
       if (!chromeShim || !chromeShim.shimPeerConnection) {
         logging('Chrome shim is not included in this adapter release.');


### PR DESCRIPTION
removes the 'opera' case. The code that set this is gone since #274.