### PR TITLE
Revert "edge: re-enable RTX"

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -385,8 +385,7 @@ var edgeShim = {
       if (recv && transceiver.rtpReceiver) {
         // remove RTX field in Edge 14942
         if (transceiver.kind === 'video'
-            && transceiver.recvEncodingParameters
-            && browserDetails.version < 15019) {
+            && transceiver.recvEncodingParameters) {
           transceiver.recvEncodingParameters.forEach(function(p) {
             delete p.rtx;
           });


### PR DESCRIPTION
This reverts commit 3a6d68a4321f841050ccde599ba9ca4f38057ea1.

While RTX works, there is more stuff that needs to be hooked up
(like an additional SSRC etc). Also that patch was incomplete
and only covered 1 out of three places where RTX was filtered out.

(landed in #419)