### PR TITLE
Fix getStats hyphen shim regression in pre-48 FF.

### DIFF
--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -158,9 +158,21 @@ var firefoxShim = {
           if (browserDetails.version < 53 && !onSucc) {
             // Shim only promise getStats with spec-hyphens in type names
             // Leave callback version alone; misc old uses of forEach before Map
-            stats.forEach(function(stat) {
-              stat.type = modernStatsTypes[stat.type] || stat.type;
-            });
+            try {
+              stats.forEach(function(stat) {
+                stat.type = modernStatsTypes[stat.type] || stat.type;
+              });
+            } catch (e) {
+              if (e.name !== 'TypeError') {
+                throw e;
+              }
+              // Avoid TypeError: "type" is read-only, in old versions. 34-43ish
+              stats.forEach(function(stat, i) {
+                stats.set(i, Object.assign({}, stat, {
+                  type: modernStatsTypes[stat.type] || stat.type
+                }));
+              });
+            }
           }
           return stats;
         })


### PR DESCRIPTION
**Description**
Fix `TypeError: "type" is read-only` error in pre-48 Firefox (regression from https://github.com/webrtc/adapter/pull/392).

**Purpose**
Make getStats work again in pre-48 Firefox.