### PR TITLE
Shim Element.setAttribute('src', URL.createObjectURL(stream)).

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -161,12 +161,11 @@ var utils = {
       }
     });
 
-    var nativeSetAttribute = Element.prototype.setAttribute;
-    Element.prototype.setAttribute = function() {
+    var nativeSetAttribute = HTMLMediaElement.prototype.setAttribute;
+    HTMLMediaElement.prototype.setAttribute = function() {
       if (arguments.length === 2 &&
           ('' + arguments[0]).toLowerCase() === 'src') {
-        this.src = arguments[1];
-        return;
+        this.srcObject = streams.get(arguments[1]) || null;
       }
       return nativeSetAttribute.apply(this, arguments);
     };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -160,6 +160,16 @@ var utils = {
         return dsc.set.apply(this, [url]);
       }
     });
+
+    var nativeSetAttribute = Element.prototype.setAttribute;
+    Element.prototype.setAttribute = function() {
+      if (arguments.length == 2 &&
+          ("" + arguments[0]).toLowerCase() === 'src') {
+        this.src = arguments[1];
+        return;
+      }
+      return nativeSetAttribute.apply(this, arguments);
+    };
   }
 };
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -163,8 +163,8 @@ var utils = {
 
     var nativeSetAttribute = Element.prototype.setAttribute;
     Element.prototype.setAttribute = function() {
-      if (arguments.length == 2 &&
-          ("" + arguments[0]).toLowerCase() === 'src') {
+      if (arguments.length === 2 &&
+          ('' + arguments[0]).toLowerCase() === 'src') {
         this.src = arguments[1];
         return;
       }

--- a/test/test.js
+++ b/test/test.js
@@ -461,7 +461,12 @@ test('createObjectURL shim test', function(t) {
         window[type + 'Stream'] = stream;
         element.id = type;
         element.autoplay = true;
-        element.src = URL.createObjectURL(stream);
+        // Test both ways of setting src
+        if (type === 'audio') {
+          element.src = URL.createObjectURL(stream);
+        } else {
+          element.setAttribute('src', URL.createObjectURL(stream));
+        }
         return new Promise(function(resolve) {
           element.addEventListener('loadedmetadata', resolve);
         });


### PR DESCRIPTION
**Description**
Fix for https://github.com/webrtc/adapter/issues/438.

**Purpose**
Make URL.createObjectURL shim work with element.setAttribute('src', ...).