### PR TITLE
test: rewrite extractVersion tests

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -68,18 +68,18 @@ var utils = {
     if (navigator.mozGetUserMedia) {
       result.browser = 'firefox';
       result.version = this.extractVersion(navigator.userAgent,
-          /Firefox\/([0-9]+)\./, 1);
+          /Firefox\/(\d+)\./, 1);
     } else if (navigator.webkitGetUserMedia) {
       // Chrome, Chromium, Webview, Opera, all use the chrome shim for now
       if (window.webkitRTCPeerConnection) {
         result.browser = 'chrome';
         result.version = this.extractVersion(navigator.userAgent,
-          /Chrom(e|ium)\/([0-9]+)\./, 2);
+          /Chrom(e|ium)\/(\d+)\./, 2);
       } else { // Safari (in an unpublished version) or unknown webkit-based.
         if (navigator.userAgent.match(/Version\/(\d+).(\d+)/)) {
           result.browser = 'safari';
           result.version = this.extractVersion(navigator.userAgent,
-            /AppleWebKit\/([0-9]+)\./, 1);
+            /AppleWebKit\/(\d+)\./, 1);
         } else { // unknown webkit-based browser.
           result.browser = 'Unsupported webkit-based browser ' +
               'with GUM support but no WebRTC support.';

--- a/test/test.js
+++ b/test/test.js
@@ -40,60 +40,6 @@ test('Log suppression', function(t) {
   t.end();
 });
 
-// Fiddle with the UA string to test the extraction does not throw errors.
-// No need for webdriver in this test.
-test('Browser version extraction helper', function(t) {
-  var utils = require('../src/js/utils.js');
-
-  // Chrome and Chromium.
-  var ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
-      'Gecko) Chrome/45.0.2454.101 Safari/537.36';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
-      'version extraction');
-
-  ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
-      'Gecko) Ubuntu Chromium/45.0.2454.85 Chrome/45.0.2454.85 Safari/537.36';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
-      'version extraction');
-
-  // Various UA strings from device simulator, not matching.
-  ua = 'Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) ' +
-      'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2307.2 Safari/537.36';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 42,
-      'version extraction');
-
-  ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
-      'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d ' +
-      'Safari/600.1.4';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), null,
-      'version extraction');
-
-  ua = 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19' +
-      '(KHTML, like Gecko) Silk/3.13 Safari/535.19 Silk-Accelerated=true';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), null,
-      'version extraction');
-
-  // Opera, should match chrome/webrtc version 45.0 not Opera 32.0.
-  ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like ' +
-      'Gecko) Chrome/45.0.2454.85 Safari/537.36 OPR/32.0.1948.44';
-  t.equal(utils.extractVersion(ua, /Chrom(e|ium)\/([0-9]+)\./, 2), 45,
-      'version extraction');
-
-  // Edge, extract build number.
-  ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, ' +
-      'like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
-  t.equal(utils.extractVersion(ua, /Edge\/(\d+).(\d+)$/, 2), 10547,
-      'version extraction');
-
-  // Firefox.
-  ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
-      'Firefox/44.0';
-  t.equal(utils.extractVersion(ua, /Firefox\/([0-9]+)\./, 1), 44,
-      'version extraction');
-
-  t.end();
-});
-
 test('Browser identified', function(t) {
   var driver = seleniumHelpers.buildDriver();
 

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('extractVersion', () => {
+  const extractVersion = require('../../src/js/utils.js').extractVersion;
+
+  let ua;
+  describe('Chrome regular expression', () => {
+    const expr = /Chrom(e|ium)\/(\d+)\./;
+
+    it('matches Chrome', () => {
+      ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+          'Gecko) Chrome/45.0.2454.101 Safari/537.36';
+      expect(extractVersion(ua, expr, 2)).to.equal(45);
+    });
+
+    it('matches Chromium', () => {
+      ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+          'Gecko) Ubuntu Chromium/45.0.2454.85 Chrome/45.0.2454.85 ' +
+          'Safari/537.36';
+      expect(extractVersion(ua, expr, 2)).to.equal(45);
+    });
+
+    it('matches Chrome on Android', () => {
+      ua = 'Mozilla/5.0 (Linux; Android 4.3; Nexus 10 Build/JSS15Q) ' +
+          'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2307.2 ' +
+          'Safari/537.36';
+      expect(extractVersion(ua, expr, 2)).to.equal(42);
+    });
+
+    it('recognizes Opera as Chrome', () => {
+      // Opera, should match chrome/webrtc version 45.0 not Opera 32.0.
+      ua = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, ' +
+          'like Gecko) Chrome/45.0.2454.85 Safari/537.36 OPR/32.0.1948.44';
+      expect(extractVersion(ua, /Chrom(e|ium)\/(\d+)\./, 2)).to.equal(45);
+    });
+
+    it('does not match Firefox', () => {
+      ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
+          'Firefox/44.0';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+
+    it('does not match Safari', () => {
+      ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+
+    it('does match Edge (by design, do not use for Edge)', () => {
+      ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+          '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
+      expect(extractVersion(ua, expr, 2)).to.equal(46);
+    });
+
+    it('does not match non-Chrome', () => {
+      ua = 'Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) ' +
+          'AppleWebKit/535.19 KHTML, like Gecko) Silk/3.13 Safari/535.19 ' +
+          'Silk-Accelerated=true';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+
+    it('does not match the iPhone simulator', () => {
+      ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
+          'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 ' +
+          'Mobile/12A4345d Safari/600.1.4';
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
+    });
+  });
+
+  describe('Firefox regular expression', () => {
+    const expr = /Firefox\/(\d+)\./;
+    it('matches Firefox', () => {
+      ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
+          'Firefox/44.0';
+      expect(extractVersion(ua, expr, 1)).to.equal(44);
+    });
+
+    it('does not match Chrome', () => {
+      ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+          'Gecko) Chrome/45.0.2454.101 Safari/537.36';
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
+    });
+
+    it('does not match Safari', () => {
+      ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
+    });
+
+    it('does not match Edge', () => {
+      ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+          '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
+    });
+  });
+
+  describe('Edge regular expression', () => {
+    const expr = /Edge\/(\d+).(\d+)$/;
+    it ('matches the Edge build number', () => {
+      ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+          '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
+      expect(extractVersion(ua, expr, 2)).to.equal(10547);
+    });
+
+    it('does not match Chrome', () => {
+      ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+          'Gecko) Chrome/45.0.2454.101 Safari/537.36';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+
+    it('does not match Firefox', () => {
+      ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
+          'Firefox/44.0';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+
+    it('does not match Safari', () => {
+      ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+      expect(extractVersion(ua, expr, 2)).to.equal(null);
+    });
+  });
+
+  describe('Safari regular expression', () => {
+    const expr = /AppleWebKit\/(\d+)/;
+    it('matches the webkit version', () => {
+      ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+      expect(extractVersion(ua, expr, 1)).to.equal(604);
+    });
+
+    it('matches the iphone simulator', () => {
+      ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
+          'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 ' +
+          'Mobile/12A4345d Safari/600.1.4';
+      expect(extractVersion(ua, expr, 1)).to.equal(600);
+    });
+
+    it('matches Chrome (by design, do not use for Chrome)', () => {
+      ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
+          'Gecko) Chrome/45.0.2454.101 Safari/537.36';
+      expect(extractVersion(ua, expr, 1)).to.equal(537);
+    });
+
+    it('matches Edge (by design, do not use for Edge', () => {
+      ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+          '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
+      expect(extractVersion(ua, expr, 1)).to.equal(537);
+    });
+
+    it('does not match Firefox', () => {
+      ua = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) Gecko/20100101 ' +
+          'Firefox/44.0';
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
+    });
+  });
+});
+


### PR DESCRIPTION
rewrites the extractVersion test. Also changes the regexp to use \d+ instead of [0-9]+