### PR TITLE
safari: detect safari without webkitGetUserMedia

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -15,7 +15,17 @@ var safariShim = {
   // shimPeerConnection: function() { },
 
   shimGetUserMedia: function() {
-    navigator.getUserMedia = navigator.webkitGetUserMedia;
+    if (!navigator.getUserMedia) {
+      if (navigator.webkitGetUserMedia) {
+        navigator.getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
+      } else if (navigator.mediaDevices &&
+          navigator.mediaDevices.getUserMedia) {
+        navigator.getUserMedia = function(constraints, cb, errcb) {
+          navigator.mediaDevices.getUserMedia(constraints)
+          .then(cb, errcb);
+        }.bind(navigator);
+      }
+    }
   }
 };
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -69,51 +69,35 @@ var utils = {
       result.browser = 'firefox';
       result.version = this.extractVersion(navigator.userAgent,
           /Firefox\/([0-9]+)\./, 1);
-
-    // all webkit-based browsers
     } else if (navigator.webkitGetUserMedia) {
       // Chrome, Chromium, Webview, Opera, all use the chrome shim for now
       if (window.webkitRTCPeerConnection) {
         result.browser = 'chrome';
         result.version = this.extractVersion(navigator.userAgent,
           /Chrom(e|ium)\/([0-9]+)\./, 2);
-
-      // Safari or unknown webkit-based
-      // for the time being Safari has support for MediaStreams but not webRTC
-      } else {
-        // Safari UA substrings of interest for reference:
-        // - webkit version:           AppleWebKit/602.1.25 (also used in Op,Cr)
-        // - safari UI version:        Version/9.0.3 (unique to Safari)
-        // - safari UI webkit version: Safari/601.4.4 (also used in Op,Cr)
-        //
-        // if the webkit version and safari UI webkit versions are equals,
-        // ... this is a stable version.
-        //
-        // only the internal webkit version is important today to know if
-        // media streams are supported
-        //
+      } else { // Safari (in an unpublished version) or unknown webkit-based.
         if (navigator.userAgent.match(/Version\/(\d+).(\d+)/)) {
           result.browser = 'safari';
           result.version = this.extractVersion(navigator.userAgent,
             /AppleWebKit\/([0-9]+)\./, 1);
-
-        // unknown webkit-based browser
-        } else {
+        } else { // unknown webkit-based browser.
           result.browser = 'Unsupported webkit-based browser ' +
               'with GUM support but no WebRTC support.';
           return result;
         }
       }
-
-    // Edge.
     } else if (navigator.mediaDevices &&
-        navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) {
+        navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) { // Edge.
       result.browser = 'edge';
       result.version = this.extractVersion(navigator.userAgent,
           /Edge\/(\d+).(\d+)$/, 2);
-
-    // Default fallthrough: not supported.
-    } else {
+    } else if (navigator.mediaDevices &&
+        navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+        // Safari, with webkitGetUserMedia removed.
+      result.browser = 'safari';
+      result.version = this.extractVersion(navigator.userAgent,
+          /AppleWebKit\/(\d+)\./, 1);
+    } else { // Default fallthrough: not supported.
       result.browser = 'Not a supported browser.';
       return result;
     }
@@ -169,5 +153,6 @@ module.exports = {
   disableLog: utils.disableLog,
   browserDetails: utils.detectBrowser(),
   extractVersion: utils.extractVersion,
-  shimCreateObjectURL: utils.shimCreateObjectURL
+  shimCreateObjectURL: utils.shimCreateObjectURL,
+  detectBrowser: utils.detectBrowser.bind(utils)
 };

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('detectBrowser', () => {
+  const detectBrowser = require('../../src/js/utils.js').detectBrowser;
+  beforeEach(() => {
+    global.window = global;
+    global.navigator = {};
+    delete window.webkitRTCPeerConnection;
+  });
+
+  it('detects Firefox if navigator.mozGetUserMedia exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; ' +
+        'rv:44.0) Gecko/20100101 Firefox/44.0';
+    navigator.mozGetUserMedia = function() {};
+
+    const browserDetails = detectBrowser();
+    expect(browserDetails.browser).to.equal('firefox');
+    expect(browserDetails.version).to.equal(44);
+  });
+
+  it('detects Chrome if navigator.webkitGetUserMedia exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (X11; Linux x86_64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 ' +
+        'Safari/537.36';
+    navigator.webkitGetUserMedia = function() {};
+    window.webkitRTCPeerConnection = function() {};
+
+    const browserDetails = detectBrowser();
+    expect(browserDetails.browser).to.equal('chrome');
+    expect(browserDetails.version).to.equal(45);
+  });
+
+  it('detects Edge if navigator.mediaDevices exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 ' +
+        'Safari/537.36 Edge/13.10547';
+    navigator.mediaDevices = function() {};
+
+    const browserDetails = detectBrowser();
+    expect(browserDetails.browser).to.equal('edge');
+    expect(browserDetails.version).to.equal(10547);
+  });
+
+  it('detects Safari if navigator.webkitGetUserMedia exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+    navigator.webkitGetUserMedia = function() {};
+
+    const browserDetails = detectBrowser();
+    expect(browserDetails.browser).to.equal('safari');
+    expect(browserDetails.version).to.equal(604);
+  });
+
+  it('detects Safari if navigator.mediaDevices exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
+          'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
+    navigator.mediaDevices = function() {};
+
+    const browserDetails = detectBrowser();
+    expect(browserDetails.browser).to.equal('safari');
+    expect(browserDetails.version).to.equal(604);
+  });
+});


### PR DESCRIPTION
detects Safari again which removed webkitGetUserMedia in the latest tech preview. Thanks @youennf for the heads-up on the change.

Also add more tests for detectBrowser.