### PR TITLE
Fix stats report type in Edge

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1099,14 +1099,13 @@ var edgeShim = {
       var cb = arguments.length > 1 && typeof arguments[1] === 'function' &&
           arguments[1];
       var fixStatsType = function(stat) {
-        stat.type = {
+        return {
           inboundrtp: 'inbound-rtp',
           outboundrtp: 'outbound-rtp',
           candidatepair: 'candidate-pair',
           localcandidate: 'local-candidate',
           remotecandidate: 'remote-candidate'
         }[stat.type] || stat.type;
-        return stat;
       };
       return new Promise(function(resolve) {
         // shim getStats with maplike support


### PR DESCRIPTION
**Description**
Fix stats report type in Edge.

**Purpose**
The `fixStatsType` function in the edge shim file returns the stats object instead of the normalized type name.