### PR TITLE
edge: add mocha unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "grunt && mocha test/unit && node test/run-tests.js"
   },
   "dependencies": {
-    "sdp": "^1.0.0"
+    "sdp": "^1.3.0"
   },
   "engines": {
     "npm": ">=3.10.0",

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -11,6 +11,27 @@
 var SDPUtils = require('sdp');
 var browserDetails = require('../utils').browserDetails;
 
+// sort tracks such that they follow an a-v-a-v...
+// pattern.
+function sortTracks(tracks) {
+  let audioTracks = tracks.filter(function(track) {
+    return track.kind === 'audio';
+  });
+  let videoTracks = tracks.filter(function(track) {
+    return track.kind === 'video';
+  });
+  tracks = [];
+  while (audioTracks.length || videoTracks.length) {
+    if (audioTracks.length) {
+      tracks.push(audioTracks.shift());
+    }
+    if (videoTracks.length) {
+      tracks.push(videoTracks.shift());
+    }
+  }
+  return tracks;
+}
+
 var edgeShim = {
   shimPeerConnection: function() {
     if (window.RTCIceGatherer) {
@@ -923,6 +944,8 @@ var edgeShim = {
           numVideoTracks--;
         }
       }
+      // reorder tracks
+      tracks = sortTracks(tracks);
 
       var sdp = SDPUtils.writeSessionBoilerplate();
       var transceivers = [];

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -1,0 +1,759 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+
+const SDPUtils = require('sdp');
+const EventEmitter = require('events');
+
+// make sure the browser detection gets the right information.
+const utils = require('../../src/js/utils');
+utils.browserDetails.browser = 'edge';
+utils.browserDetails.version = 15025;
+
+function mockORTC() {
+  // required by the shim to mock an EventEmitter.
+  global.document = {
+    createDocumentFragment: () => {
+      let e = new EventEmitter();
+      e.addEventListener = e.addListener.bind(e);
+      e.removeEventListener = e.removeListener.bind(e);
+      e.dispatchEvent = function(ev) {
+        e.emit(ev.type, ev);
+      };
+      return e;
+    }
+  };
+  global.Event = function(type) {
+    this.type = type;
+  };
+
+  global.RTCSessionDescription = function(init) {
+    return init;
+  };
+
+  global.RTCIceGatherer = function() {
+    this.getLocalParameters = function() {
+      return {
+        usernameFragment: 'someufrag',
+        password: 'somepass'
+      };
+    };
+  };
+  global.RTCIceTransport = function() {};
+  global.RTCDtlsTransport = function() {
+    this.getLocalParameters = function() {
+      return {
+        role: 'auto',
+        fingerprints: [
+          {
+            algorithm: 'alg',
+            value: 'fi:ng:ger:pr:in:t1'
+          }
+        ]
+      };
+    };
+  };
+
+  global.RTCRtpReceiver = function(transport, kind) {
+    this.track = new MediaStreamTrack();
+    this.track.kind = kind;
+    this.transport = transport;
+
+    this.receive = function(params) {};
+  };
+  function getCapabilities(kind) {
+    var opus = {
+      name: 'opus',
+      kind: 'audio',
+      clockRate: 48000,
+      preferredPayloadType: 111,
+      numChannels: 2
+    };
+    var vp8 = {
+      name: 'vp8',
+      kind: 'video',
+      clockRate: 90000,
+      preferredPayloadType: 100,
+      numChannels: 1
+    };
+    var codecs;
+    switch (kind) {
+      case 'audio':
+        codecs = [opus];
+        break;
+      case 'video':
+        codecs = [vp8];
+        break;
+      default:
+        codecs = [opus, vp8];
+        break;
+    }
+    return {
+      codecs: codecs,
+      headerExtensions: []
+    };
+  }
+  RTCRtpReceiver.getCapabilities = getCapabilities;
+
+  global.RTCRtpSender = function(track, transport) {
+    this.track = track;
+    this.transport = transport;
+  };
+  RTCRtpSender.getCapabilities = getCapabilities;
+
+  global.MediaStream = function(tracks) {
+    this.id = SDPUtils.generateIdentifier();
+    this._tracks = tracks || [];
+    this.getTracks = () => this._tracks;
+    this.getAudioTracks = () => this._tracks.filter(t => t.kind === 'audio');
+    this.getVideoTracks = () => this._tracks.filter(t => t.kind === 'video');
+    this.addTrack = (t) => this._tracks.push(t);
+  };
+  global.MediaStreamTrack = function() {
+    this.id = SDPUtils.generateIdentifier();
+  };
+}
+
+describe('Edge shim', () => {
+  global.navigator = {
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+        '(KHTML, like Gecko) Chrome/52.0.2743.116 Safari/537.36 Edge/15.15031',
+    mediaDevices: function() {}
+  };
+  global.window = global;
+
+  const shim = require('../../src/js/edge/edge_shim');
+
+  beforeEach(() => {
+    mockORTC();
+    shim.shimPeerConnection();
+  });
+
+  it('creates window.RTCPeerConnection', () => {
+    delete window.RTCPeerConnection;
+    shim.shimPeerConnection();
+    expect(window.RTCPeerConnection).not.to.equal(undefined);
+  });
+
+  it('overrides window.RTCPeerConnection if it exists', () => {
+    global.window.RTCPeerConnection = true;
+    shim.shimPeerConnection();
+    expect(window.RTCPeerConnection).not.to.equal(true);
+  });
+
+  describe('setLocalDescription', () => {
+    let pc;
+    beforeEach(() => {
+      pc = new RTCPeerConnection();
+    });
+
+    it('returns a promise', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then((offer) => {
+        return pc.setLocalDescription(offer);
+      })
+      .then(done);
+    });
+
+    it('calls the legacy success callback', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then((offer) => {
+        return pc.setLocalDescription(offer, done);
+      });
+    });
+
+    it('changes the signalingState to have-local-offer', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then((offer) => {
+        return pc.setLocalDescription(offer);
+      })
+      .then(() => {
+        expect(pc.localDescription.type).to.equal('offer');
+        expect(pc.signalingState = 'have-local-offer');
+        done();
+      });
+    });
+  });
+
+  describe('setRemoteDescription', () => {
+    let pc;
+    beforeEach(() => {
+      pc = new RTCPeerConnection();
+    });
+
+    it('returns a promise', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(done);
+    });
+    it('calls the legacy success callback', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp}, done);
+    });
+
+    it('changes the signalingState to have-remote-offer', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(() => {
+        expect(pc.signalingState = 'have-remote-offer');
+        done();
+      });
+    });
+
+    it('sets the remoteDescription', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp}, () => {
+        expect(pc.remoteDescription.type).to.equal('offer');
+        expect(pc.remoteDescription.sdp).to.equal(sdp);
+        done();
+      });
+    });
+
+    describe('when called with an offer containing a track', () => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n' +
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendonly\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:111 opus/48000\r\n' +
+          'a=ssrc:1001 msid:stream1 track1\r\n' +
+          'a=ssrc:1001 cname:some\r\n';
+      it('triggers onaddstream', (done) => {
+        pc.onaddstream = function(event) {
+          const stream = event.stream;
+          expect(stream.getTracks().length).to.equal(1);
+          expect(stream.getTracks()[0].kind).to.equal('audio');
+
+          done();
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+
+      it('emits a addstream event', (done) => {
+        pc.addEventListener('addstream', function(event) {
+          const stream = event.stream;
+          expect(stream.getTracks().length).to.equal(1);
+          expect(stream.getTracks()[0].kind).to.equal('audio');
+
+          done();
+        });
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+
+      it('triggers ontrack', (done) => {
+        pc.ontrack = function(event) {
+          expect(event.track.kind).to.equal('audio');
+          expect(event.receiver);
+          expect(event.streams.length).to.equal(1);
+
+          done();
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+
+      it('emits a track event', (done) => {
+        pc.addEventListener('track', function(event) {
+          expect(event.track.kind).to.equal('audio');
+          expect(event.receiver);
+          expect(event.streams.length).to.equal(1);
+
+          done();
+        });
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+    });
+
+    describe('when called with an offer without (explicit) tracks', () => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\n' +
+          // 'a=msid-semantic: WMS\r\n' + // no msid-semantic
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendonly\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:111 opus/48000\r\n';
+
+      it('triggers onaddstream', (done) => {
+        pc.onaddstream = function(event) {
+          const stream = event.stream;
+          expect(stream.getTracks().length).to.equal(1);
+          expect(stream.getTracks()[0].kind).to.equal('audio');
+
+          done();
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+
+      it('triggers ontrack', (done) => {
+        pc.ontrack = function(event) {
+          expect(event.track.kind).to.equal('audio');
+          expect(event.receiver);
+          expect(event.streams.length).to.equal(1);
+          done();
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+    });
+
+    describe.skip('when called with an offer containing multiple streams ' +
+        '/ tracks', () => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n' +
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendonly\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:111 opus/48000\r\n' +
+          'a=ssrc:1001 msid:stream1 track1\r\n' +
+          'a=ssrc:1001 cname:some\r\n' +
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendonly\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:111 opus/48000\r\n' +
+          'a=ssrc:2002 msid:stream2 track2\r\n' +
+          'a=ssrc:2002 cname:some\r\n';
+
+      it('triggers onaddstream twice', (done) => {
+        let numStreams = 0;
+        pc.onaddstream = function(event) {
+          numStreams++;
+          expect(event.stream.id).to.equal('stream' + numStreams);
+          if (numStreams === 2) {
+            done();
+          }
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+
+      it('triggers ontrack twice', (done) => {
+        let numTracks = 0;
+        pc.ontrack = function(event) {
+          numTracks++;
+          expect(event.streams[0].id).to.equal('stream' + numTracks);
+          if (numTracks === 2) {
+            done();
+          }
+        };
+        pc.setRemoteDescription({type: 'offer', sdp: sdp});
+      });
+    });
+
+    // TODO: add a test for recvonly to show it doesn't trigger the callback.
+    //   probably easiest done using a sinon.stub
+  });
+
+  describe('createOffer', () => {
+    let pc;
+    beforeEach(() => {
+      pc = new RTCPeerConnection();
+    });
+
+    it('returns a promise', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then(() => {
+        done();
+      });
+    });
+    it('calls the legacy success callback', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then(() => {
+        done();
+      });
+    });
+    it('does not change the signalingState', (done) => {
+      pc.createOffer({offerToReceiveAudio: 1})
+      .then(() => {
+        expect(pc.signalingState).to.equal('stable');
+        done();
+      });
+    });
+
+    describe('when called with offerToReceiveAudio', () => {
+      it('= 1 the generated SDP should contain one audio m-line', (done) => {
+        pc.createOffer({offerToReceiveAudio: 1})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(2);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+          done();
+        });
+      });
+      it('= 2 the generated SDP should contain two audio m-lines', (done) => {
+        pc.createOffer({offerToReceiveAudio: 2})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(3);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+          expect(SDPUtils.getDirection(sections[2])).to.equal('recvonly');
+          done();
+        });
+      });
+    });
+
+    describe('when called with offerToReceiveVideo', () => {
+      it('the generated SDP should contain a video m-line', (done) => {
+        pc.createOffer({offerToReceiveVideo: 1})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(2);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+          done();
+        });
+      });
+    });
+
+    describe('when called with offerToReceiveAudio and ' +
+        'offerToReceiveVideo', () => {
+      it('the generated SDP should contain two m-lines', (done) => {
+        pc.createOffer({offerToReceiveAudio: 1, offerToReceiveVideo: 1})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(3);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+          expect(SDPUtils.getKind(sections[1])).to.equal('audio');
+          expect(SDPUtils.getDirection(sections[2])).to.equal('recvonly');
+          expect(SDPUtils.getKind(sections[2])).to.equal('video');
+          done();
+        });
+      });
+    });
+
+    describe('when called after adding a stream', () => {
+      describe('with an audio track', () => {
+        it('the generated SDP should contain an audio m-line', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const stream = new MediaStream([audioTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer()
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(2);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('sendrecv');
+            done();
+          });
+        });
+      });
+
+      describe('with an audio track not offering to receive audio', () => {
+        it('the generated SDP should contain a sendonly audio ' +
+            'm-line', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const stream = new MediaStream([audioTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer({offerToReceiveAudio: 0})
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(2);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('sendonly');
+            done();
+          });
+        });
+      });
+
+      describe('with an audio track and offering to receive video', () => {
+        it('the generated SDP should contain a recvonly m-line', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const stream = new MediaStream([audioTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer({offerToReceiveVideo: 1})
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(3);
+            expect(SDPUtils.getKind(sections[1])).to.equal('audio');
+            expect(SDPUtils.getDirection(sections[1])).to.equal('sendrecv');
+            expect(SDPUtils.getKind(sections[2])).to.equal('video');
+            expect(SDPUtils.getDirection(sections[2])).to.equal('recvonly');
+            done();
+          });
+        });
+      });
+
+      describe('with a video track', () => {
+        it('the generated SDP should contain an video m-line', (done) => {
+          const videoTrack = new MediaStreamTrack();
+          videoTrack.kind = 'video';
+          const stream = new MediaStream([videoTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer()
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(2);
+            expect(SDPUtils.getKind(sections[1])).to.equal('video');
+            done();
+          });
+        });
+      });
+
+      describe('with a video track and offerToReceiveAudio', () => {
+        it('the generated SDP should contain an audio and a ' +
+            'video m-line', (done) => {
+          const videoTrack = new MediaStreamTrack();
+          videoTrack.kind = 'video';
+          const stream = new MediaStream([videoTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer({offerToReceiveAudio: 1})
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(3);
+            expect(SDPUtils.getKind(sections[1])).to.equal('audio');
+            expect(SDPUtils.getKind(sections[2])).to.equal('video');
+            done();
+          });
+        });
+      });
+
+
+      describe('with an audio track and a video track', () => {
+        it('the generated SDP should contain an audio and video ' +
+            'm-line', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const videoTrack = new MediaStreamTrack();
+          videoTrack.kind = 'video';
+          const stream = new MediaStream([audioTrack, videoTrack]);
+
+          pc.addStream(stream);
+          pc.createOffer()
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(3);
+            expect(SDPUtils.getKind(sections[1])).to.equal('audio');
+            expect(SDPUtils.getKind(sections[2])).to.equal('video');
+            done();
+          });
+        });
+      });
+
+      describe.skip('with an audio track and two video tracks', () => {
+        it('the generated SDP should contain an audio and ' +
+            'video m-line', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const videoTrack = new MediaStreamTrack();
+          videoTrack.kind = 'video';
+          const videoTrack2 = new MediaStreamTrack();
+          videoTrack2.kind = 'video';
+          const stream = new MediaStream([audioTrack, videoTrack]);
+          const stream2 = new MediaStream([videoTrack2]);
+
+          pc.addStream(stream);
+          pc.addStream(stream2);
+          pc.createOffer()
+          .then((offer) => {
+            const sections = SDPUtils.splitSections(offer.sdp);
+            expect(sections.length).to.equal(4);
+            expect(SDPUtils.getKind(sections[1])).to.equal('audio');
+            expect(SDPUtils.getKind(sections[2])).to.equal('video');
+            expect(SDPUtils.getKind(sections[3])).to.equal('video');
+            done();
+          });
+        });
+      });
+    });
+  });
+
+  describe('createAnswer', () => {
+    let pc;
+    beforeEach(() => {
+      pc = new RTCPeerConnection();
+    });
+
+    it('returns a promise', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(() => {
+        return pc.createAnswer();
+      })
+      .then(() => {
+        done();
+      });
+    });
+    it('calls the legacy success callback', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(() => {
+        return pc.createAnswer(() => {
+          done();
+        });
+      });
+    });
+
+    it('does not change the signaling state', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(() => {
+        expect(pc.signalingState).to.equal('have-remote-offer');
+        return pc.createAnswer();
+      })
+      .then(() => {
+        expect(pc.signalingState).to.equal('have-remote-offer');
+        done();
+      });
+    });
+
+    it('uses payload types of offerer', (done) => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n' +
+          'm=audio 9 UDP/TLS/RTP/SAVPF 98\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendrecv\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:98 opus/48000\r\n' +
+          'a=ssrc:1001 msid:stream1 track1\r\n' +
+          'a=ssrc:1001 cname:some\r\n';
+      pc.setRemoteDescription({type: 'offer', sdp: sdp})
+      .then(() => {
+        return pc.createAnswer();
+      })
+      .then((answer) => {
+        expect(answer.sdp).to.contain('a=rtpmap:98 opus');
+        done();
+      });
+    });
+
+    // test https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-15#section-5.3.4
+    describe('direction attribute', () => {
+      const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
+          's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n' +
+          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
+          'c=IN IP4 0.0.0.0\r\n' +
+          'a=rtcp:9 IN IP4 0.0.0.0\r\na=ice-ufrag:foo\r\na=ice-pwd:bar\r\n' +
+          'a=fingerprint:sha-256 so:me:co:lo:ns\r\n' +
+          'a=setup:actpass\r\n' +
+          'a=mid:audio1\r\n' +
+          'a=sendrecv\r\na=rtcp-mux\r\n' +
+          'a=rtcp-rsize\r\n' +
+          'a=rtpmap:111 opus/48000\r\n' +
+          'a=ssrc:1001 msid:stream1 track1\r\n' +
+          'a=ssrc:1001 cname:some\r\n';
+
+      it.skip('responds with a inactive answer to inactive', (done) => {
+        pc.setRemoteDescription({type: 'offer', sdp: sdp.replace('sendrecv',
+            'recvonly')})
+        .then(() => {
+          return pc.createAnswer();
+        })
+        .then((answer) => {
+          const sections = SDPUtils.splitSections(answer.sdp);
+          expect(sections.length).to.equal(2);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('inactive');
+          done();
+        });
+      });
+
+      describe('with a local track', () => {
+        beforeEach(() => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const stream = new MediaStream([audioTrack]);
+
+          pc.addStream(stream);
+        });
+
+        it('responds with a sendrecv answer to sendrecv', (done) => {
+          pc.setRemoteDescription({type: 'offer', sdp: sdp})
+          .then(() => {
+            return pc.createAnswer();
+          })
+          .then((answer) => {
+            const sections = SDPUtils.splitSections(answer.sdp);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('sendrecv');
+            done();
+          });
+        });
+
+        it.skip('responds with a sendonly answer to recvonly', (done) => {
+          const audioTrack = new MediaStreamTrack();
+          audioTrack.kind = 'audio';
+          const videoTrack = new MediaStreamTrack();
+          videoTrack.kind = 'video';
+          const stream = new MediaStream([audioTrack, videoTrack]);
+
+          pc.addStream(stream);
+          pc.setRemoteDescription({type: 'offer', sdp: sdp.replace('sendrecv',
+              'recvonly')})
+          .then(() => {
+            return pc.createAnswer();
+          })
+          .then((answer) => {
+            const sections = SDPUtils.splitSections(answer.sdp);
+            expect(sections.length).to.equal(2);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('sendonly');
+            done();
+          });
+        });
+      });
+
+      describe('with no local track', () => {
+        it('responds with a recvonly answer to sendrecv', (done) => {
+          pc.setRemoteDescription({type: 'offer', sdp: sdp})
+          .then(() => {
+            return pc.createAnswer();
+          })
+          .then((answer) => {
+            const sections = SDPUtils.splitSections(answer.sdp);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+            done();
+          });
+        });
+
+        it.skip('responds with a inactive answer to recvonly', (done) => {
+          pc.setRemoteDescription({type: 'offer', sdp: sdp.replace('sendrecv',
+              'recvonly')})
+          .then(() => {
+            return pc.createAnswer();
+          })
+          .then((answer) => {
+            const sections = SDPUtils.splitSections(answer.sdp);
+            expect(SDPUtils.getDirection(sections[1])).to.equal('inactive');
+            done();
+          });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
also fixes an issue with the sorting of tracks. Now it does audio-video-audio-video.

The tests contain some unified-plan tests which are currently deactivated.

When hta is back we should talk about whether those tests make sense in web-platform-tests.