### PR TITLE
Filter multiple valid turn server entries in Edge

### DIFF
--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -186,6 +186,36 @@ describe('Edge shim', () => {
       });
       expect(pc.iceOptions.iceServers).to.deep.equal([]);
     });
+
+    it('removes all but the first server of a type in separate entries', () => {
+      pc = new RTCPeerConnection({
+        iceServers: [
+          {urls: 'stun:stun.l.google.com'},
+          {urls: 'turn:stun.l.google.com:19301?transport=udp'},
+          {urls: 'turn:stun.l.google.com:19302?transport=udp'}
+        ]
+      });
+      expect(pc.iceOptions.iceServers).to.deep.equal([
+        {urls: 'stun:stun.l.google.com'},
+        {urls: 'turn:stun.l.google.com:19301?transport=udp'}
+      ]);
+    });
+
+    it('removes all but the first server of a type in urls entry', () => {
+      pc = new RTCPeerConnection({
+        iceServers: [
+          {urls: 'stun:stun.l.google.com'},
+          {urls: [
+            'turn:stun.l.google.com:19301?transport=udp',
+            'turn:stun.l.google.com:19302?transport=udp'
+          ]}
+        ]
+      });
+      expect(pc.iceOptions.iceServers).to.deep.equal([
+        {urls: 'stun:stun.l.google.com'},
+        {urls: ['turn:stun.l.google.com:19301?transport=udp']}
+      ]);
+    });
   });
 
   describe('setLocalDescription', () => {

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -187,34 +187,36 @@ describe('Edge shim', () => {
       expect(pc.iceOptions.iceServers).to.deep.equal([]);
     });
 
-    it('removes all but the first server of a type in separate entries', () => {
-      pc = new RTCPeerConnection({
-        iceServers: [
+    describe('removes all but the first server of a type', () => {
+      it('in separate entries', () => {
+        pc = new RTCPeerConnection({
+          iceServers: [
+            {urls: 'stun:stun.l.google.com'},
+            {urls: 'turn:stun.l.google.com:19301?transport=udp'},
+            {urls: 'turn:stun.l.google.com:19302?transport=udp'}
+          ]
+        });
+        expect(pc.iceOptions.iceServers).to.deep.equal([
           {urls: 'stun:stun.l.google.com'},
-          {urls: 'turn:stun.l.google.com:19301?transport=udp'},
-          {urls: 'turn:stun.l.google.com:19302?transport=udp'}
-        ]
+          {urls: 'turn:stun.l.google.com:19301?transport=udp'}
+        ]);
       });
-      expect(pc.iceOptions.iceServers).to.deep.equal([
-        {urls: 'stun:stun.l.google.com'},
-        {urls: 'turn:stun.l.google.com:19301?transport=udp'}
-      ]);
-    });
 
-    it('removes all but the first server of a type in urls entry', () => {
-      pc = new RTCPeerConnection({
-        iceServers: [
+      it('in urls entries', () => {
+        pc = new RTCPeerConnection({
+          iceServers: [
+            {urls: 'stun:stun.l.google.com'},
+            {urls: [
+              'turn:stun.l.google.com:19301?transport=udp',
+              'turn:stun.l.google.com:19302?transport=udp'
+            ]}
+          ]
+        });
+        expect(pc.iceOptions.iceServers).to.deep.equal([
           {urls: 'stun:stun.l.google.com'},
-          {urls: [
-            'turn:stun.l.google.com:19301?transport=udp',
-            'turn:stun.l.google.com:19302?transport=udp'
-          ]}
-        ]
+          {urls: ['turn:stun.l.google.com:19301?transport=udp']}
+        ]);
       });
-      expect(pc.iceOptions.iceServers).to.deep.equal([
-        {urls: 'stun:stun.l.google.com'},
-        {urls: ['turn:stun.l.google.com:19301?transport=udp']}
-      ]);
     });
   });
 


### PR DESCRIPTION
**Description**
Edge throws an error when using multiple valid turn servers (https://github.com/webrtc/adapter/issues/451). This is an attempt to fix it by filtering out additional turn servers.

It filters servers in `.url`, multiple servers in `.urls` and in separate ice server entries.

**Purpose**
Filter out any additional turn servers in the ice servers array to prevent Edge from throwing an error when creating a `RTCPeerConnection`.