### PR TITLE
edge: dont use ES6 let in sortTracks

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -14,10 +14,10 @@ var browserDetails = require('../utils').browserDetails;
 // sort tracks such that they follow an a-v-a-v...
 // pattern.
 function sortTracks(tracks) {
-  let audioTracks = tracks.filter(function(track) {
+  var audioTracks = tracks.filter(function(track) {
     return track.kind === 'audio';
   });
-  let videoTracks = tracks.filter(function(track) {
+  var videoTracks = tracks.filter(function(track) {
     return track.kind === 'video';
   });
   tracks = [];


### PR DESCRIPTION
separated from #458 

this was a whoops. We are still trying to be ES5, right? Then why didn't eslint yell at me...