### PR TITLE
edge: add partial support for unified plan

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -622,7 +622,7 @@ var edgeShim = {
     window.RTCPeerConnection.prototype.setRemoteDescription =
         function(description) {
           var self = this;
-          var stream = new MediaStream();
+          var streams = {};
           var receiverList = [];
           var sections = SDPUtils.splitSections(description.sdp);
           var sessionpart = sections.shift();
@@ -636,6 +636,7 @@ var edgeShim = {
             var kind = mline[0];
             var rejected = mline[1] === '0';
             var direction = SDPUtils.getDirection(mediaSection, sessionpart);
+            var remoteMsid = SDPUtils.parseMsid(mediaSection);
 
             var mid = SDPUtils.matchPrefix(mediaSection, 'a=mid:');
             if (mid.length) {
@@ -720,10 +721,31 @@ var edgeShim = {
                     kind);
 
                 track = rtpReceiver.track;
-                receiverList.push([track, rtpReceiver]);
-                // FIXME: not correct when there are multiple streams but that
-                // is not currently supported in this shim.
-                stream.addTrack(track);
+                // FIXME: does not work with Plan B.
+                if (remoteMsid) {
+                  if (!streams[remoteMsid.stream]) {
+                    streams[remoteMsid.stream] = new MediaStream();
+                    Object.defineProperty(streams[remoteMsid.stream], 'id', {
+                      get: function() {
+                        return remoteMsid.stream;
+                      }
+                    });
+                  }
+                  Object.defineProperty(track, 'id', {
+                    get: function() {
+                      return remoteMsid.track;
+                    }
+                  });
+                  streams[remoteMsid.stream].addTrack(track);
+                  receiverList.push([track, rtpReceiver,
+                      streams[remoteMsid.stream]]);
+                } else {
+                  if (!streams.default) {
+                    streams.default = new MediaStream();
+                  }
+                  streams.default.addTrack(track);
+                  receiverList.push([track, rtpReceiver, streams.default]);
+                }
               }
 
               // FIXME: look at direction.
@@ -808,7 +830,17 @@ var edgeShim = {
                   (direction === 'sendrecv' || direction === 'sendonly')) {
                 track = rtpReceiver.track;
                 receiverList.push([track, rtpReceiver]);
-                stream.addTrack(track);
+                if (remoteMsid) {
+                  if (!streams[remoteMsid.stream]) {
+                    streams[remoteMsid.stream] = new MediaStream();
+                  }
+                  streams[remoteMsid.stream].addTrack(track);
+                } else {
+                  if (!streams.default) {
+                    streams.default = new MediaStream();
+                  }
+                  streams.default.addTrack(track);
+                }
               } else {
                 // FIXME: actually the receiver should be created later.
                 delete transceiver.rtpReceiver;
@@ -832,9 +864,10 @@ var edgeShim = {
               throw new TypeError('unsupported type "' + description.type +
                   '"');
           }
-          if (stream.getTracks().length) {
-            self.remoteStreams.push(stream);
-            window.setTimeout(function() {
+          Object.keys(streams).forEach(function(sid) {
+            var stream = streams[sid];
+            if (stream.getTracks().length) {
+              self.remoteStreams.push(stream);
               var event = new Event('addstream');
               event.stream = stream;
               self.dispatchEvent(event);
@@ -847,6 +880,9 @@ var edgeShim = {
               receiverList.forEach(function(item) {
                 var track = item[0];
                 var receiver = item[1];
+                if (stream.id !== item[2].id) {
+                  return;
+                }
                 var trackEvent = new Event('track');
                 trackEvent.track = track;
                 trackEvent.receiver = receiver;
@@ -858,8 +894,8 @@ var edgeShim = {
                   }, 0);
                 }
               });
-            }, 0);
-          }
+            }
+          });
           if (arguments.length > 1 && typeof arguments[1] === 'function') {
             window.setTimeout(arguments[1], 0);
           }
@@ -972,8 +1008,12 @@ var edgeShim = {
       var numVideoTracks = 0;
       // Default to sendrecv.
       if (this.localStreams.length) {
-        numAudioTracks = this.localStreams[0].getAudioTracks().length;
-        numVideoTracks = this.localStreams[0].getVideoTracks().length;
+        numAudioTracks = this.localStreams.reduce(function(numTracks, stream) {
+          return numTracks + stream.getAudioTracks().length;
+        }, 0);
+        numVideoTracks = this.localStreams.reduce(function(numTracks, stream) {
+          return numTracks + stream.getVideoTracks().length;
+        }, 0);
       }
       // Determine number of audio and video tracks we need to send/recv.
       if (offerOptions) {
@@ -989,12 +1029,14 @@ var edgeShim = {
           numVideoTracks = offerOptions.offerToReceiveVideo;
         }
       }
-      if (this.localStreams.length) {
-        // Push local streams.
-        this.localStreams[0].getTracks().forEach(function(track) {
+
+      // Push local streams.
+      this.localStreams.forEach(function(localStream) {
+        localStream.getTracks().forEach(function(track) {
           tracks.push({
             kind: track.kind,
             track: track,
+            stream: localStream,
             wantReceive: track.kind === 'audio' ?
                 numAudioTracks > 0 : numVideoTracks > 0
           });
@@ -1004,7 +1046,8 @@ var edgeShim = {
             numVideoTracks--;
           }
         });
-      }
+      });
+
       // Create M-lines for recvonly streams.
       while (numAudioTracks > 0 || numVideoTracks > 0) {
         if (numAudioTracks > 0) {
@@ -1104,7 +1147,7 @@ var edgeShim = {
       tracks.forEach(function(mline, sdpMLineIndex) {
         var transceiver = transceivers[sdpMLineIndex];
         sdp += SDPUtils.writeMediaSection(transceiver,
-            transceiver.localCapabilities, 'offer', self.localStreams[0]);
+            transceiver.localCapabilities, 'offer', mline.stream);
         sdp += 'a=rtcp-rsize\r\n';
       });
 

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -395,7 +395,7 @@ describe('Edge shim', () => {
       });
     });
 
-    describe.skip('when called with an offer containing multiple streams ' +
+    describe('when called with an offer containing multiple streams ' +
         '/ tracks', () => {
       const sdp = 'v=0\r\no=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
           's=-\r\nt=0 0\r\na=msid-semantic: WMS\r\n' +
@@ -641,7 +641,7 @@ describe('Edge shim', () => {
         });
       });
 
-      describe.skip('with an audio track and two video tracks', () => {
+      describe('with an audio track and two video tracks', () => {
         it('the generated SDP should contain an audio and ' +
             'video m-line', (done) => {
           const audioTrack = new MediaStreamTrack();


### PR DESCRIPTION
adds partial support for Unified Plan in Edge.
This is limited to creating offers after calling addStream multiple times.
Renegotiation is not supported.

On the receiving end this adds support for parsing MSID and overrides
the native stream and track ids with the stream and track ids from the
SDP.