### PR TITLE
edge: export shimReplaceTrack

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -1265,5 +1265,6 @@ var edgeShim = {
 // Expose public methods.
 module.exports = {
   shimPeerConnection: edgeShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia')
+  shimGetUserMedia: require('./getusermedia'),
+  shimReplaceTrack: edgeShim.shimReplaceTrack
 };


### PR DESCRIPTION
I wonder if we should just do ```module.exports =``` instead of creating an object that is only used in a single place. Same for other browsers...