### PR TITLE
chrome: backfill RTCIceServer.urls from .url

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -165,6 +165,35 @@ var chromeShim = {
           }
         });
       }
+    } else {
+      // migrate from non-spec RTCIceServer.url to RTCIceServer.urls
+      var OrigPeerConnection = RTCPeerConnection;
+      window.RTCPeerConnection = function(pcConfig, pcConstraints) {
+        if (pcConfig && pcConfig.iceServers) {
+          var newIceServers = [];
+          for (var i = 0; i < pcConfig.iceServers.length; i++) {
+            var server = pcConfig.iceServers[i];
+            if (!server.hasOwnProperty('urls') &&
+                server.hasOwnProperty('url')) {
+              console.warn('RTCIceServer.url is deprecated! Use urls instead.');
+              server = JSON.parse(JSON.stringify(server));
+              server.urls = server.url;
+              newIceServers.push(server);
+            } else {
+              newIceServers.push(pcConfig.iceServers[i]);
+            }
+          }
+          pcConfig.iceServers = newIceServers;
+        }
+        return new OrigPeerConnection(pcConfig, pcConstraints);
+      };
+      window.RTCPeerConnection.prototype = OrigPeerConnection.prototype;
+      // wrap static methods. Currently just generateCertificate.
+      Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
+        get: function() {
+          return OrigPeerConnection.generateCertificate;
+        }
+      });
     }
 
     var origGetStats = RTCPeerConnection.prototype.getStats;

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -43,6 +43,9 @@ function filterIceServers(iceServers) {
   return iceServers.filter(function(server) {
     if (server && (server.urls || server.url)) {
       var urls = server.urls || server.url;
+      if (server.url && !server.urls) {
+        console.warn('RTCIceServer.url is deprecated! Use urls instead.');
+      }
       var isString = typeof urls === 'string';
       if (isString) {
         urls = [urls];

--- a/test/unit/chrome.js
+++ b/test/unit/chrome.js
@@ -23,12 +23,5 @@ describe('Chrome shim', () => {
       shim.shimPeerConnection();
       expect(window.RTCPeerConnection).not.to.equal(undefined);
     });
-
-    it('does not override window.RTCPeerConnection if it exists', () => {
-      const pc = function() {};
-      global.window.RTCPeerConnection = pc;
-      shim.shimPeerConnection();
-      expect(window.RTCPeerConnection).to.equal(pc);
-    });
   });
 });


### PR DESCRIPTION
apparently there is a significant number of folks who still have
not upgraded from RTCIceServer.url to RTCIceServer.urls.
Let adapter do this for them.

cc @foolip