### PR TITLE
edge: move getCommonCapabilities out of the RTRCPeerConnection object

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -70,6 +70,85 @@ function filterIceServers(iceServers, edgeVersion) {
   });
 }
 
+// Determines the intersection of local and remote capabilities.
+function getCommonCapabilities(localCapabilities, remoteCapabilities) {
+  var commonCapabilities = {
+    codecs: [],
+    headerExtensions: [],
+    fecMechanisms: []
+  };
+
+  var findCodecByPayloadType = function(pt, codecs) {
+    pt = parseInt(pt, 10);
+    for (var i = 0; i < codecs.length; i++) {
+      if (codecs[i].payloadType === pt ||
+          codecs[i].preferredPayloadType === pt) {
+        return codecs[i];
+      }
+    }
+  };
+
+  var rtxCapabilityMatches = function(lRtx, rRtx, lCodecs, rCodecs) {
+    var lCodec = findCodecByPayloadType(lRtx.parameters.apt, lCodecs);
+    var rCodec = findCodecByPayloadType(rRtx.parameters.apt, rCodecs);
+    return lCodec && rCodec &&
+        lCodec.name.toLowerCase() === rCodec.name.toLowerCase();
+  };
+
+  localCapabilities.codecs.forEach(function(lCodec) {
+    for (var i = 0; i < remoteCapabilities.codecs.length; i++) {
+      var rCodec = remoteCapabilities.codecs[i];
+      if (lCodec.name.toLowerCase() === rCodec.name.toLowerCase() &&
+          lCodec.clockRate === rCodec.clockRate) {
+        if (lCodec.name.toLowerCase() === 'rtx' &&
+            lCodec.parameters && rCodec.parameters.apt) {
+          // for RTX we need to find the local rtx that has a apt
+          // which points to the same local codec as the remote one.
+          if (!rtxCapabilityMatches(lCodec, rCodec,
+              localCapabilities.codecs, remoteCapabilities.codecs)) {
+            continue;
+          }
+        }
+        rCodec = JSON.parse(JSON.stringify(rCodec)); // deepcopy
+        // number of channels is the highest common number of channels
+        rCodec.numChannels = Math.min(lCodec.numChannels,
+            rCodec.numChannels);
+        // push rCodec so we reply with offerer payload type
+        commonCapabilities.codecs.push(rCodec);
+
+        // determine common feedback mechanisms
+        rCodec.rtcpFeedback = rCodec.rtcpFeedback.filter(function(fb) {
+          for (var j = 0; j < lCodec.rtcpFeedback.length; j++) {
+            if (lCodec.rtcpFeedback[j].type === fb.type &&
+                lCodec.rtcpFeedback[j].parameter === fb.parameter) {
+              return true;
+            }
+          }
+          return false;
+        });
+        // FIXME: also need to determine .parameters
+        //  see https://github.com/openpeer/ortc/issues/569
+        break;
+      }
+    }
+  });
+
+  localCapabilities.headerExtensions.forEach(function(lHeaderExtension) {
+    for (var i = 0; i < remoteCapabilities.headerExtensions.length;
+         i++) {
+      var rHeaderExtension = remoteCapabilities.headerExtensions[i];
+      if (lHeaderExtension.uri === rHeaderExtension.uri) {
+        commonCapabilities.headerExtensions.push(rHeaderExtension);
+        break;
+      }
+    }
+  });
+
+  // FIXME: fecMechanisms
+  return commonCapabilities;
+}
+
+
 module.exports = function(edgeVersion) {
   var RTCPeerConnection = function(config) {
     var self = this;
@@ -238,86 +317,6 @@ module.exports = function(edgeVersion) {
     });
   };
 
-  // Determines the intersection of local and remote capabilities.
-  RTCPeerConnection.prototype._getCommonCapabilities = function(
-      localCapabilities, remoteCapabilities) {
-    var commonCapabilities = {
-      codecs: [],
-      headerExtensions: [],
-      fecMechanisms: []
-    };
-
-    var findCodecByPayloadType = function(pt, codecs) {
-      pt = parseInt(pt, 10);
-      for (var i = 0; i < codecs.length; i++) {
-        if (codecs[i].payloadType === pt ||
-            codecs[i].preferredPayloadType === pt) {
-          return codecs[i];
-        }
-      }
-    };
-
-    var rtxCapabilityMatches = function(lRtx, rRtx, lCodecs, rCodecs) {
-      var lCodec = findCodecByPayloadType(lRtx.parameters.apt, lCodecs);
-      var rCodec = findCodecByPayloadType(rRtx.parameters.apt, rCodecs);
-      return lCodec && rCodec &&
-          lCodec.name.toLowerCase() === rCodec.name.toLowerCase();
-    };
-
-    localCapabilities.codecs.forEach(function(lCodec) {
-      for (var i = 0; i < remoteCapabilities.codecs.length; i++) {
-        var rCodec = remoteCapabilities.codecs[i];
-        if (lCodec.name.toLowerCase() === rCodec.name.toLowerCase() &&
-            lCodec.clockRate === rCodec.clockRate) {
-          if (lCodec.name.toLowerCase() === 'rtx' &&
-              lCodec.parameters && rCodec.parameters.apt) {
-            // for RTX we need to find the local rtx that has a apt
-            // which points to the same local codec as the remote one.
-            if (!rtxCapabilityMatches(lCodec, rCodec,
-                localCapabilities.codecs, remoteCapabilities.codecs)) {
-              continue;
-            }
-          }
-          rCodec = JSON.parse(JSON.stringify(rCodec)); // deepcopy
-          // number of channels is the highest common number of channels
-          rCodec.numChannels = Math.min(lCodec.numChannels,
-              rCodec.numChannels);
-          // push rCodec so we reply with offerer payload type
-          commonCapabilities.codecs.push(rCodec);
-
-          // determine common feedback mechanisms
-          rCodec.rtcpFeedback = rCodec.rtcpFeedback.filter(function(fb) {
-            for (var j = 0; j < lCodec.rtcpFeedback.length; j++) {
-              if (lCodec.rtcpFeedback[j].type === fb.type &&
-                  lCodec.rtcpFeedback[j].parameter === fb.parameter) {
-                return true;
-              }
-            }
-            return false;
-          });
-          // FIXME: also need to determine .parameters
-          //  see https://github.com/openpeer/ortc/issues/569
-          break;
-        }
-      }
-    });
-
-    localCapabilities.headerExtensions
-        .forEach(function(lHeaderExtension) {
-          for (var i = 0; i < remoteCapabilities.headerExtensions.length;
-               i++) {
-            var rHeaderExtension = remoteCapabilities.headerExtensions[i];
-            if (lHeaderExtension.uri === rHeaderExtension.uri) {
-              commonCapabilities.headerExtensions.push(rHeaderExtension);
-              break;
-            }
-          }
-        });
-
-    // FIXME: fecMechanisms
-    return commonCapabilities;
-  };
-
   // Create ICE gatherer, ICE transport and DTLS transport.
   RTCPeerConnection.prototype._createIceAndDtlsTransports = function(mid,
       sdpMLineIndex) {
@@ -442,7 +441,7 @@ module.exports = function(edgeVersion) {
   // Start the RTP Sender and Receiver for a transceiver.
   RTCPeerConnection.prototype._transceive = function(transceiver,
       send, recv) {
-    var params = this._getCommonCapabilities(transceiver.localCapabilities,
+    var params = getCommonCapabilities(transceiver.localCapabilities,
         transceiver.remoteCapabilities);
     if (send && transceiver.rtpSender) {
       params.encodings = transceiver.sendEncodingParameters;
@@ -528,7 +527,7 @@ module.exports = function(edgeVersion) {
           }
 
           // Calculate intersection of capabilities.
-          var params = self._getCommonCapabilities(localCapabilities,
+          var params = getCommonCapabilities(localCapabilities,
               remoteCapabilities);
 
           // Start the RTCRtpSender. The RTCRtpReceiver for this
@@ -1161,7 +1160,7 @@ module.exports = function(edgeVersion) {
         return;
       }
       // Calculate intersection of capabilities.
-      var commonCapabilities = self._getCommonCapabilities(
+      var commonCapabilities = getCommonCapabilities(
           transceiver.localCapabilities,
           transceiver.remoteCapabilities);
 


### PR DESCRIPTION
technically this is a breaking change... however that API has intentionally been marked as private by using a underscore...