### PR TITLE
edge: add support for boolean offerToReceive*

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -1004,10 +1004,22 @@ module.exports = function(edgeVersion) {
             'Legacy mandatory/optional constraints not supported.');
       }
       if (offerOptions.offerToReceiveAudio !== undefined) {
-        numAudioTracks = offerOptions.offerToReceiveAudio;
+        if (offerOptions.offerToReceiveAudio === true) {
+          numAudioTracks = 1;
+        } else if (offerOptions.offerToReceiveAudio === false) {
+          numAudioTracks = 0;
+        } else {
+          numAudioTracks = offerOptions.offerToReceiveAudio;
+        }
       }
       if (offerOptions.offerToReceiveVideo !== undefined) {
-        numVideoTracks = offerOptions.offerToReceiveVideo;
+        if (offerOptions.offerToReceiveVideo === true) {
+          numVideoTracks = 1;
+        } else if (offerOptions.offerToReceiveVideo === false) {
+          numVideoTracks = 0;
+        } else {
+          numVideoTracks = offerOptions.offerToReceiveVideo;
+        }
       }
     }
 

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -524,6 +524,30 @@ describe('Edge shim', () => {
           done();
         });
       });
+      it('= true the generated SDP should contain one audio m-line', (done) => {
+        pc.createOffer({offerToReceiveAudio: true})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(2);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('recvonly');
+          done();
+        });
+      });
+      it('= false the generated SDP should not offer to receive ' +
+          'audio', (done) => {
+        const audioTrack = new MediaStreamTrack();
+        audioTrack.kind = 'audio';
+        const stream = new MediaStream([audioTrack]);
+
+        pc.addStream(stream);
+        pc.createOffer({offerToReceiveAudio: false})
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(2);
+          expect(SDPUtils.getDirection(sections[1])).to.equal('sendonly');
+          done();
+        });
+      });
     });
 
     describe('when called with offerToReceiveVideo', () => {


### PR DESCRIPTION
which have been re-added to the spec recently.