### PR TITLE
Start PulseAudio and re-enable Firefox stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
-sudo: false
+dist: trusty
 language: node_js
 node_js:
 - 6
 
+addons:
+  apt:
+    packages:
+      - pulseaudio
+
 env:
+  global:
+    - DISPLAY=:99.0
+
   matrix:
     - BROWSER=chrome  BVER=stable
     - BROWSER=chrome  BVER=beta
     - BROWSER=chrome  BVER=unstable
     - BROWSER=firefox BVER=stable
+    - BROWSER=firefox BVER=beta
     - BROWSER=firefox BVER=nightly
     - BROWSER=firefox BVER=esr
 
@@ -16,16 +25,14 @@ matrix:
   fast_finish: true
 
   allow_failures:
-    - env: BROWSER=firefox BVER=stable
     - env: BROWSER=chrome  BVER=unstable
-    - env: BROWSER=firefox BVER=beta
     - env: BROWSER=firefox BVER=nightly
     - env: BROWSER=firefox BVER=esr
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh
-  - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
+  - pulseaudio --start
 
 script:
   - node_modules/.bin/grunt


### PR DESCRIPTION
Firefox requires PulseAudio on Linux. See [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1247056). I was getting

```
$ pulseaudio --start
E: [pulseaudio] client-conf-x11.c: xcb_connection_has_error() returned true
E: [pulseaudio] main.c: Daemon startup failed.
```

until I updated `dist`. Not sure why, but it appears to be working now. EDIT: Also added back Firefox beta.