### PR TITLE
Use native RTCPeerConnection API on Edge when available

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -71,6 +71,10 @@ function filterIceServers(iceServers, edgeVersion) {
 }
 
 module.exports = function(edgeVersion) {
+  if (window.RTCPeerConnection) {
+    return RTCPeerConnection;
+  }
+
   var RTCPeerConnection = function(config) {
     var self = this;
 


### PR DESCRIPTION
**Description**
Prevent overriding the original implemented `RTCPeerConnection` API when it is available.

**Purpose**
Since WebRTC API is introduced in the latest release version of edge as noted [here](https://blogs.windows.com/msedgedev/2017/01/31/introducing-webrtc-microsoft-edge/), it would be awesome to use the native implemented `RTCPeerConnection` API when available.
