### PR TITLE
chrome: return empty array from getSenders

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -58,7 +58,7 @@ var chromeShim = {
         !('getSenders' in RTCPeerConnection.prototype) &&
         'createDTMFSender' in RTCPeerConnection.prototype) {
       RTCPeerConnection.prototype.getSenders = function() {
-        return this._senders;
+        return this._senders || [];
       };
       var origAddStream = RTCPeerConnection.prototype.addStream;
       var origRemoveStream = RTCPeerConnection.prototype.removeStream;


### PR DESCRIPTION
makes getSenders return an empty array when called before addStream/addTrack.

No test. This belongs into a wpt test imo :-)

@jan-ivar PTAL