### PR TITLE
in strict mode cant update state. This fixes that.

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -406,7 +406,8 @@ module.exports = function(edgeVersion) {
     };
     dtlsTransport.onerror = function() {
       // onerror does not set state to failed by itself.
-      Object.defineProperty(dtlsTransport, "state", {value : 'failed', writable : true})
+      Object.defineProperty(dtlsTransport, "state",
+          {value : 'failed', writable : true});
       self._updateConnectionState();
     };
 

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -406,7 +406,7 @@ module.exports = function(edgeVersion) {
     };
     dtlsTransport.onerror = function() {
       // onerror does not set state to failed by itself.
-      dtlsTransport.state = 'failed';
+      Object.defineProperty(dtlsTransport, "state", {value : 'failed', writable : true})
       self._updateConnectionState();
     };
 

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -406,7 +406,8 @@ module.exports = function(edgeVersion) {
     };
     dtlsTransport.onerror = function() {
       // onerror does not set state to failed by itself.
-      Object.defineProperty(dtlsTransport, "state", {value : 'failed', writable : true})
+      Object.defineProperty(dtlsTransport, 'state',
+          {value: 'failed', writable: true});
       self._updateConnectionState();
     };
 


### PR DESCRIPTION
in Edge when the dtls was failing also getting an error 
"Assignment to read-only properties is not allowed in strict mode"
