### PR TITLE
Adding shims for addStream and legacy callback APIs

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -89,6 +89,8 @@
       // Export to the adapter global object visible in the browser.
       module.exports.browserShim = safariShim;
 
+      safariShim.shimCallbacksAPI();
+      safariShim.shimAddStream();
       safariShim.shimOnAddStream();
       safariShim.shimGetUserMedia();
       break;

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -18,7 +18,7 @@ var safariShim = {
         !('addStream' in window.RTCPeerConnection.prototype)) {
       RTCPeerConnection.prototype.addStream = function(stream) {
         stream.getTracks().forEach(track => this.addTrack(track, stream));
-      }
+      };
     }
   },
   shimOnAddStream: function() {
@@ -52,53 +52,63 @@ var safariShim = {
     }
   },
   shimCallbacksAPI: function() {
-    if (typeof window !== 'object' || !window.RTCPeerConnection)
+    if (typeof window !== 'object' || !window.RTCPeerConnection) {
       return;
-    var createOffer = RTCPeerConnection.prototype.createOffer;
-    var createAnswer = RTCPeerConnection.prototype.createAnswer;
-    var setLocalDescription = RTCPeerConnection.prototype.setLocalDescription;
-    var setRemoteDescription = RTCPeerConnection.prototype.setRemoteDescription;
-    var addIceCandidate = RTCPeerConnection.prototype.addIceCandidate;
+    }
+    var prototype = RTCPeerConnection.prototype;
+    var createOffer = prototype.createOffer;
+    var createAnswer = prototype.createAnswer;
+    var setLocalDescription = prototype.setLocalDescription;
+    var setRemoteDescription = prototype.setRemoteDescription;
+    var addIceCandidate = prototype.addIceCandidate;
 
-    RTCPeerConnection.prototype.createOffer = function(successCallback, failureCallback) {
+    prototype.createOffer = function(successCallback, failureCallback) {
       var promise = createOffer.apply(this, [arguments[2]]);
-      if (!failureCallback)
+      if (!failureCallback) {
         return promise;
+      }
       promise.then(successCallback, failureCallback);
       return Promise.resolve();
-    }
+    };
 
-    RTCPeerConnection.prototype.createAnswer = function(successCallback, failureCallback) {
+    prototype.createAnswer = function(successCallback, failureCallback) {
       var promise = createAnswer.apply(this);
-      if (!failureCallback)
+      if (!failureCallback) {
         return promise;
+      }
       promise.then(successCallback, failureCallback);
       return Promise.resolve();
-    }
+    };
 
-    RTCPeerConnection.prototype.setLocalDescription = function(description, successCallback, failureCallback) {
+    var withCallback = function(description, successCallback, failureCallback) {
       var promise = setLocalDescription.apply(this, [description]);
-      if (!failureCallback)
+      if (!failureCallback) {
         return promise;
+      }
       promise.then(successCallback, failureCallback);
       return Promise.resolve();
-    }
+    };
+    prototype.setLocalDescription = withCallback;
 
-    RTCPeerConnection.prototype.setRemoteDescription = function(description, successCallback, failureCallback) {
+    withCallback = function(description, successCallback, failureCallback) {
       var promise = setRemoteDescription.apply(this, [description]);
-      if (!failureCallback)
+      if (!failureCallback) {
         return promise;
+      }
       promise.then(successCallback, failureCallback);
       return Promise.resolve();
-    }
+    };
+    prototype.setRemoteDescription = withCallback;
 
-    RTCPeerConnection.prototype.addIceCandidate = function(candidate, successCallback, failureCallback) {
+    withCallback = function(candidate, successCallback, failureCallback) {
       var promise = addIceCandidate.apply(this, [candidate]);
-      if (!failureCallback)
+      if (!failureCallback) {
         return promise;
+      }
       promise.then(successCallback, failureCallback);
       return Promise.resolve();
-    }
+    };
+    prototype.addIceCandidate = withCallback;
   },
   shimGetUserMedia: function() {
     if (!navigator.getUserMedia) {

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -63,7 +63,8 @@ var safariShim = {
     var addIceCandidate = prototype.addIceCandidate;
 
     prototype.createOffer = function(successCallback, failureCallback) {
-      var promise = createOffer.apply(this, [arguments[2]]);
+      var options = (arguments.length >= 2) ? arguments[2] : arguments[0];
+      var promise = createOffer.apply(this, [options]);
       if (!failureCallback) {
         return promise;
       }
@@ -72,7 +73,8 @@ var safariShim = {
     };
 
     prototype.createAnswer = function(successCallback, failureCallback) {
-      var promise = createAnswer.apply(this);
+      var options = (arguments.length >= 2) ? arguments[2] : arguments[0];
+      var promise = createAnswer.apply(this, [options]);
       if (!failureCallback) {
         return promise;
       }

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -7,26 +7,26 @@ describe('Safari shim', () => {
 
   beforeEach(() => {
     global.window = global;
-    delete global.RTCPeerConnection;
+    global.RTCPeerConnection = function() {};
   });
 
   describe('shimCallbacksAPI', () => {
     it('shimCallbacksAPI existence', () => {
       shim.shimCallbacksAPI();
-      //expect(window.RTCPeerConnection).not.to.equal(undefined);
-      expect(window.RTCPeerConnection.prototype.createOffer.length).to.equal(2);
-      expect(window.RTCPeerConnection.prototype.createAnswer.length).to.equal(2);
-      expect(window.RTCPeerConnection.prototype.setLocalDescription.length).to.equal(3);
-      expect(window.RTCPeerConnection.prototype.setRemoteDescription.length).to.equal(3);
-      expect(window.RTCPeerConnection.prototype.addIceCandidate.length).to.equal(3);
+      var prototype = window.RTCPeerConnection.prototype;
+      expect(prototype.createOffer.length).to.equal(2);
+      expect(prototype.createAnswer.length).to.equal(2);
+      expect(prototype.setLocalDescription.length).to.equal(3);
+      expect(prototype.setRemoteDescription.length).to.equal(3);
+      expect(prototype.addIceCandidate.length).to.equal(3);
     });
   });
 
   describe('shimAddStream', () => {
     it('shimAddStream existence', () => {
       shim.shimAddStream();
-      expect(RTCPeerConnection).not.to.equal(undefined);
-      expect(RTCPeerConnection.prototype.addStream.length).to.equal(1);
+      var prototype = window.RTCPeerConnection.prototype;
+      expect(prototype.addStream.length).to.equal(1);
     });
   });
 });

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -1,0 +1,32 @@
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('Safari shim', () => {
+  const shim = require('../../src/js/safari/safari_shim');
+
+  beforeEach(() => {
+    global.window = global;
+    delete global.RTCPeerConnection;
+  });
+
+  describe('shimCallbacksAPI', () => {
+    it('shimCallbacksAPI existence', () => {
+      shim.shimCallbacksAPI();
+      //expect(window.RTCPeerConnection).not.to.equal(undefined);
+      expect(window.RTCPeerConnection.prototype.createOffer.length).to.equal(2);
+      expect(window.RTCPeerConnection.prototype.createAnswer.length).to.equal(2);
+      expect(window.RTCPeerConnection.prototype.setLocalDescription.length).to.equal(3);
+      expect(window.RTCPeerConnection.prototype.setRemoteDescription.length).to.equal(3);
+      expect(window.RTCPeerConnection.prototype.addIceCandidate.length).to.equal(3);
+    });
+  });
+
+  describe('shimAddStream', () => {
+    it('shimAddStream existence', () => {
+      shim.shimAddStream();
+      expect(RTCPeerConnection).not.to.equal(undefined);
+      expect(RTCPeerConnection.prototype.addStream.length).to.equal(1);
+    });
+  });
+});

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -21,6 +21,46 @@ describe('Safari shim', () => {
       expect(prototype.addIceCandidate.length).to.equal(3);
     });
   });
+  describe('createAnswer/createOffer shiming', () => {
+    it('createAnswer/createOffer options passing', () => {
+      var createOfferOptions, createAnswerOptions;
+      global.RTCPeerConnection = function() {};
+      global.RTCPeerConnection.prototype = {
+        createOffer: (options) => {
+          createOfferOptions = options;
+          return Promise.resolve();
+        },
+        createAnswer: (options) => {
+          createAnswerOptions = options;
+          return Promise.resolve();
+        }
+      };
+      shim.shimCallbacksAPI();
+      var prototype = window.RTCPeerConnection.prototype;
+
+      prototype.createOffer();
+      expect(createOfferOptions).to.equal(undefined);
+      prototype.createOffer(null, null);
+      expect(createOfferOptions).to.equal(undefined);
+      prototype.createOffer(1);
+      expect(createOfferOptions).to.equal(1);
+      prototype.createOffer(null, null, 1);
+      expect(createOfferOptions).to.equal(1);
+      prototype.createOffer(null, null, 1, 2);
+      expect(createOfferOptions).to.equal(1);
+
+      prototype.createAnswer();
+      expect(createAnswerOptions).to.equal(undefined);
+      prototype.createAnswer(null, null);
+      expect(createAnswerOptions).to.equal(undefined);
+      prototype.createAnswer(1);
+      expect(createAnswerOptions).to.equal(1);
+      prototype.createAnswer(null, null, 1);
+      expect(createAnswerOptions).to.equal(1);
+      prototype.createAnswer(null, null, 1, 2);
+      expect(createAnswerOptions).to.equal(1);
+    });
+  });
 
   describe('shimAddStream', () => {
     it('shimAddStream existence', () => {


### PR DESCRIPTION
**Description**
Adding legacy APIs (addStream) and callback support for setRemoteDescription, setLocalDescription, addIceCandidate, createOffer and createAnswer for Safari.

**Purpose**
Support some legacy websites.