### PR TITLE
test: use sinon and sinon-chai for unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "grunt-githooks": "^0.3.1",
     "mocha": "^3.2.0",
     "selenium-webdriver": "3.3.0",
+    "sinon": "^2.2.0",
+    "sinon-chai": "^2.10.0",
     "tape": "^4.0.0",
     "travis-multirunner": "^3.0.1"
   }


### PR DESCRIPTION
uses [sinon](http://sinonjs.org/) and [sinon-chai](https://github.com/domenic/sinon-chai)
for unit testing

@youennf what do you think? I also noticed that the legacy createAnswer technically doesn't have answer options... see issue over on webrtc-pc