### PR TITLE
edge: improve negotiationneeded

### DIFF
--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -1295,4 +1295,27 @@ describe('Edge shim', () => {
       });
     });
   });
+
+  describe('negotationneeded', () => {
+    it('fires asynchronously after addTrack', (done) => {
+      const pc = new RTCPeerConnection();
+
+      const audioTrack = new MediaStreamTrack();
+      audioTrack.kind = 'audio';
+      const videoTrack = new MediaStreamTrack();
+      videoTrack.kind = 'video';
+      const stream = new MediaStream([audioTrack, videoTrack]);
+
+      pc.onnegotiationneeded = function(e) {
+        pc.createOffer()
+        .then((offer) => {
+          const sections = SDPUtils.splitSections(offer.sdp);
+          expect(sections.length).to.equal(3);
+          done();
+        });
+      };
+      pc.addTrack(audioTrack, stream); // onn should not execute now.
+      pc.addTrack(videoTrack, stream); // but after this.
+    });
+  });
 });


### PR DESCRIPTION
improves the maybeFireNegotiationNeeded implementation to work
better with addTrack in the future.

the requirement here is that ONN does not fire too early for this:
```
// let stream have an audio and a video track...

pc.onnegotationneeded = () => {
  // should be called after both tracks have been added
};
stream.getTracks().forEach((t) => {
  pc.addTrack(t);
})
```

hrm... maybe I can get @pthatcherg to review this? 👋 