### PR TITLE
chrome/firefox: shim GUM NotReadableError

### DIFF
--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -120,8 +120,9 @@ module.exports = function() {
   var shimError_ = function(e) {
     return {
       name: {
+        ConstraintNotSatisfiedError: 'OverconstrainedError',
         PermissionDeniedError: 'NotAllowedError',
-        ConstraintNotSatisfiedError: 'OverconstrainedError'
+        TrackStartError: 'NotReadableError'
       }[e.name] || e.name,
       message: e.message,
       constraint: e.constraintName,

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -16,9 +16,10 @@ module.exports = function() {
   var shimError_ = function(e) {
     return {
       name: {
+        InternalError: 'NotReadableError',
         NotSupportedError: 'TypeError',
-        SecurityError: 'NotAllowedError',
-        PermissionDeniedError: 'NotAllowedError'
+        PermissionDeniedError: 'NotAllowedError',
+        SecurityError: 'NotAllowedError'
       }[e.name] || e.name,
       message: {
         'The operation is insecure.': 'The request is not allowed by the ' +


### PR DESCRIPTION
translates wrong errors from Chrome/Firefox into the error
given by the spec here:
    https://w3c.github.io/mediacapture-main/getusermedia.html#dom-mediadevices-getusermedia

Lets not add hacks without filing issues:
Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1363779
Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=651910#c17