### PR TITLE
Update grunt-eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
         {"SwitchCase": 1}
     ],
     "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
+    "keyword-spacing": 2,
     "max-len": [2, 80, 2, {"ignoreUrls": true}],
     "new-cap": [2, {"newIsCapExceptions": [
         "webkitRTCPeerConnection",
@@ -38,7 +39,6 @@
         2,
         "always"
     ],
-    "space-after-keywords": 2,
     "space-before-blocks": 2,
     "space-before-function-paren": [2, "never"],
     "space-unary-ops": 2,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -36,8 +36,8 @@ module.exports = function(grunt) {
           }
         }
       },
-      // Use this if you do not want Microsoft Edge shim to be included and do not
-      // want adapter to expose anything to the global scope.
+      // Use this if you do not want Microsoft Edge shim to be included and
+      // do not want adapter to expose anything to the global scope.
       adapterNoEdgeAndNoGlobalObject: {
         src: ['./src/js/adapter_core.js'],
         dest: './out/adapter_no_edge_no_global.js',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-cli": ">=0.1.9",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
-    "grunt-eslint": "^17.2.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-githooks": "^0.3.1",
     "mocha": "^3.2.0",
     "selenium-webdriver": "3.3.0",

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -256,7 +256,7 @@ var chromeShim = {
       // shim getStats with maplike support
       var makeMapStats = function(stats) {
         return new Map(Object.keys(stats).map(function(key) {
-          return[key, stats[key]];
+          return [key, stats[key]];
         }));
       };
 
@@ -266,7 +266,7 @@ var chromeShim = {
         };
 
         return origGetStats.apply(this, [successCallbackWrapper_,
-            arguments[0]]);
+          arguments[0]]);
       }
 
       // promise-support

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -157,9 +157,9 @@ module.exports = function() {
           return MediaStreamTrack.getSources(function(devices) {
             resolve(devices.map(function(device) {
               return {label: device.label,
-                      kind: kinds[device.kind],
-                      deviceId: device.id,
-                      groupId: ''};
+                kind: kinds[device.kind],
+                deviceId: device.id,
+                groupId: ''};
             }));
           });
         });

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -745,7 +745,7 @@ module.exports = function(edgeVersion) {
             });
             streams[remoteMsid.stream].addTrack(track);
             receiverList.push([track, rtpReceiver,
-                streams[remoteMsid.stream]]);
+              streams[remoteMsid.stream]]);
           } else {
             if (!streams.default) {
               streams.default = new MediaStream();
@@ -1303,11 +1303,11 @@ module.exports = function(edgeVersion) {
     var promises = [];
     this.transceivers.forEach(function(transceiver) {
       ['rtpSender', 'rtpReceiver', 'iceGatherer', 'iceTransport',
-          'dtlsTransport'].forEach(function(method) {
-            if (transceiver[method]) {
-              promises.push(transceiver[method].getStats());
-            }
-          });
+        'dtlsTransport'].forEach(function(method) {
+          if (transceiver[method]) {
+            promises.push(transceiver[method].getStats());
+          }
+        });
     });
     var cb = arguments.length > 1 && typeof arguments[1] === 'function' &&
         arguments[1];

--- a/test/test.js
+++ b/test/test.js
@@ -841,7 +841,7 @@ test('Check getUserMedia legacy constraints converter', function(t) {
           navigator.getUserMedia(beforeAfter[0], function() {}, function() {});
         });
         window.constraintsArray.push([constraints, beforeAfter[1], gum,
-            counter + 1]);
+          counter + 1]);
       });
     }
 
@@ -1811,7 +1811,7 @@ test('video loadedmetadata is called for a video call', function(t) {
   .then(function(error) {
     // Callback will either return an error object or pc1ConnectionStatus.
     if (error) {
-      throw(error);
+      throw (error);
     }
     return driver.executeScript('return window.testPassed');
   })
@@ -2044,10 +2044,10 @@ test('getStats', {skip: true}, function(t) {
     })
     .then(function(report) {
       window.testsEqualArray.push([typeof report, 'object',
-          'report is an object.']);
+        'report is an object.']);
       report.forEach((stat, key) => {
         window.testsEqualArray.push([stat.id, key,
-            'report key matches stats id.']);
+          'report key matches stats id.']);
       });
       return report;
     })
@@ -2059,7 +2059,7 @@ test('getStats', {skip: true}, function(t) {
           continue;
         }
         window.testsEqualArray.push([report[key].id, key,
-            'legacy report key matches stats id.']);
+          'legacy report key matches stats id.']);
       }
       callback(null);
     })
@@ -2126,13 +2126,13 @@ test('originalChromeGetStats', function(t) {
       // webdriver.
       reports.forEach(function(report) {
         window.testsEqualArray.push([typeof report, 'object',
-            'report is an object']);
+          'report is an object']);
         window.testsEqualArray.push([typeof report.id, 'string',
-            'report.id is a string']);
+          'report.id is a string']);
         window.testsEqualArray.push([typeof report.type, 'string',
-            'report.type is a string']);
+          'report.type is a string']);
         window.testsEqualArray.push([typeof report.timestamp, 'object',
-            'report.timestamp is an object']);
+          'report.timestamp is an object']);
         report.names().forEach(function(name) {
           window.testsNotEqualArray.push([report.stat(name), null,
             'stat ' + name + ' not equal to null']);
@@ -2212,7 +2212,7 @@ test('getStats promise', function(t) {
     pc1.getStats(null)
     .then(function(report) {
       testsEqualArray.push([typeof report, 'object',
-          'getStats with no selector returns a Promise']);
+        'getStats with no selector returns a Promise']);
       // Firefox does not like getStats without any arguments, therefore we call
       // the callback before the next getStats call.
       // FIXME: Remove this if ever supported by Firefox, also remove the t.skip
@@ -2224,7 +2224,7 @@ test('getStats promise', function(t) {
       pc1.getStats()
       .then(function(reportWithoutArg) {
         testsEqualArray.push([typeof reportWithoutArg, 'object',
-            'getStats with no arguments returns a Promise']);
+          'getStats with no arguments returns a Promise']);
         callback(testsEqualArray);
       })
       .catch(function(err) {
@@ -2295,7 +2295,7 @@ test('iceTransportPolicy relay functionality',
         window.candidates = [];
 
         var pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay',
-            iceServers: []});
+          iceServers: []});
 
         // Since we try to gather only relay candidates without specifying
         // a TURN server, we should not get any candidates.
@@ -2572,13 +2572,13 @@ test('Non-module logging to console still works', function(t) {
 
     // Check for existence of variables and functions from public API.
     window.testsEqualArray.push([typeof RTCPeerConnection,'function',
-        'RTCPeerConnection is a function']);
+      'RTCPeerConnection is a function']);
     window.testsEqualArray.push([typeof navigator.getUserMedia, 'function',
-        'getUserMedia is a function']);
+      'getUserMedia is a function']);
     window.testsEqualArray.push([typeof window.adapter.browserDetails.browser,
-        'string', 'browserDetails.browser browser is a string']);
+      'string', 'browserDetails.browser browser is a string']);
     window.testsEqualArray.push([typeof window.adapter.browserDetails.version,
-        'number', 'browserDetails.version is a number']);
+      'number', 'browserDetails.version is a number']);
   };
 
   // Run test.

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -1089,7 +1089,7 @@ describe('Edge shim', () => {
 
       it('not set if the offer did not contain rtcp-rsize', (done) => {
         pc.setRemoteDescription({type: 'offer',
-            sdp: sdp.replace('a=rtcp-rsize\r\n', '')})
+          sdp: sdp.replace('a=rtcp-rsize\r\n', '')})
         .then(() => {
           return pc.createAnswer();
         })


### PR DESCRIPTION
**Description**

- Update ESLint dep from `^1.0.0` to `^3.0.0`
- Update a deprecated rule
- Lint code with `eslint --fix` command

**Purpose**

The last version of ESLint will give a proper support for ES module (https://github.com/webrtc/adapter/pull/515). 

I am looking for a way to transition smoothly the repo to ES module. I will create small PR to avoid conflicts and to not interfere with your work 👍 