### PR TITLE
Integrate Babel in toolchain

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,9 @@
+{
+  "presets": [
+    ["env", {
+      "targets": {
+        "browsers": ["last 1 version"]
+      }
+    }]
+  ]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -57,5 +57,8 @@
     "process": true,
     "Promise": true,
     "Map": true
+  },
+  "parserOptions": {
+      "sourceType": "module"
   }
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,6 +46,9 @@ module.exports = function(grunt) {
             './src/js/edge/edge_shim.js'
           ]
         }
+      },
+      options: {
+        transform: ['babelify']
       }
     },
     githooks: {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "version": "",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir -p adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
-    "test": "grunt && mocha test/unit && karma start test/karma.conf.js && node test/run-tests.js"
+    "test": "grunt && mocha --compilers js:babel-core/register test/unit && karma start test/karma.conf.js && node test/run-tests.js"
   },
   "dependencies": {
     "sdp": "^2.1.0"
@@ -27,6 +27,9 @@
   },
   "devDependencies": {
     "brfs": "^1.4.3",
+    "babel-core": "^6.24.1",
+    "babel-preset-env": "^1.4.0",
+    "babelify": "^7.3.0",
     "chai": "^3.5.0",
     "chromedriver": "^2.29.0",
     "eslint-config-webrtc": "^1.0.0",


### PR DESCRIPTION
**Description**

- Add Babel plugin to Browserify pipeline (with `babel-preset-env` and its configuration)
- Add Babel plugin to Mocha runner

**Purpose**

Integrate Babel will allow new JS syntax (including `import`/`export`) in the repo and can avoid this kind of modification https://github.com/webrtc/adapter/pull/537. It is a better approach than my previous PR https://github.com/webrtc/adapter/pull/515 as it keeps the same tools and gives time to transition (or not).

Last one after I stop pushing 😅 