### PR TITLE
edge: fix bundle parsing

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -695,6 +695,7 @@ module.exports = function(edgeVersion) {
         'a=ice-lite').length > 0;
     var usingBundle = SDPUtils.matchPrefix(sessionpart,
         'a=group:BUNDLE ').length > 0;
+    this.usingBundle = usingBundle;
     var iceOptions = SDPUtils.matchPrefix(sessionpart,
         'a=ice-options:')[0];
     if (iceOptions) {
@@ -900,7 +901,6 @@ module.exports = function(edgeVersion) {
         }
       }
     });
-    this.usingBundle = usingBundle;
 
     this.remoteDescription = {
       type: description.type,


### PR DESCRIPTION
fixes a regression where the second transport was
created even though BUNDLE was used.

Introduced in #528 :-/