### PR TITLE
edge: fix bundle issue

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -764,6 +764,26 @@ module.exports = function(window, edgeVersion) {
           .filter(function(cand) {
             return cand.component === '1' || cand.component === 1;
           });
+
+      // Check if we can use BUNDLE and dispose transports.
+      if ((description.type === 'offer' || description.type === 'answer') &&
+          !rejected && usingBundle && sdpMLineIndex > 0) {
+        self._disposeIceAndDtlsTransports(sdpMLineIndex);
+        self.transceivers[sdpMLineIndex].iceGatherer =
+            self.transceivers[0].iceGatherer;
+        self.transceivers[sdpMLineIndex].iceTransport =
+            self.transceivers[0].iceTransport;
+        self.transceivers[sdpMLineIndex].dtlsTransport =
+            self.transceivers[0].dtlsTransport;
+        if (self.transceivers[sdpMLineIndex].rtpSender) {
+          self.transceivers[sdpMLineIndex].rtpSender.setTransport(
+              self.transceivers[0].dtlsTransport);
+        }
+        if (self.transceivers[sdpMLineIndex].rtpReceiver) {
+          self.transceivers[sdpMLineIndex].rtpReceiver.setTransport(
+              self.transceivers[0].dtlsTransport);
+        }
+      }
       if (description.type === 'offer' && !rejected) {
         transceiver = self.transceivers[sdpMLineIndex] ||
             self._createTransceiver(kind);
@@ -839,23 +859,6 @@ module.exports = function(window, edgeVersion) {
             false,
             direction === 'sendrecv' || direction === 'sendonly');
       } else if (description.type === 'answer' && !rejected) {
-        if (usingBundle && sdpMLineIndex > 0) {
-          self._disposeIceAndDtlsTransports(sdpMLineIndex);
-          self.transceivers[sdpMLineIndex].iceGatherer =
-              self.transceivers[0].iceGatherer;
-          self.transceivers[sdpMLineIndex].iceTransport =
-              self.transceivers[0].iceTransport;
-          self.transceivers[sdpMLineIndex].dtlsTransport =
-              self.transceivers[0].dtlsTransport;
-          if (self.transceivers[sdpMLineIndex].rtpSender) {
-            self.transceivers[sdpMLineIndex].rtpSender.setTransport(
-                self.transceivers[0].dtlsTransport);
-          }
-          if (self.transceivers[sdpMLineIndex].rtpReceiver) {
-            self.transceivers[sdpMLineIndex].rtpReceiver.setTransport(
-                self.transceivers[0].dtlsTransport);
-          }
-        }
         transceiver = self.transceivers[sdpMLineIndex];
         iceGatherer = transceiver.iceGatherer;
         iceTransport = transceiver.iceTransport;


### PR DESCRIPTION
the code did not handle this rather common case:
```
pc.addStream(stream);
pc.setRemoteDescription(type=offer, sdp: bundle-av)
```
and did not dispose the second transport leading to
a weird connection failure.

the test looks like this but my infrastructure has disgressed too much to add it back here:
```
    describe('when called with a bundle offer after adding ' +
        'two tracks', () => {
      const sdp = SDP_BOILERPLATE +
          'a=group:BUNDLE audio1 video1\r\n' +
          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
          'c=IN IP4 0.0.0.0\r\n' +
          'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
          'a=ice-ufrag:' + ICEUFRAG + '\r\n' +
          'a=ice-pwd:' + ICEPWD + '\r\n' +
          'a=fingerprint:sha-256 ' + FINGERPRINT_SHA256 + '\r\n' +
          'a=setup:actpass\r\n' +
          'a=mid:audio1\r\n' +
          'a=sendonly\r\n' +
          'a=rtcp-mux\r\n' +
          'a=rtcp-rsize\r\n' +
          'a=rtpmap:111 opus/48000/2\r\n' +
          'a=ssrc:1001 msid:stream1 track1\r\n' +
          'a=ssrc:1001 cname:some\r\n' +
          'm=audio 9 UDP/TLS/RTP/SAVPF 111\r\n' +
          'c=IN IP4 0.0.0.0\r\n' +
          'a=rtcp:9 IN IP4 0.0.0.0\r\n' +
          'a=ice-ufrag:' + ICEUFRAG + '\r\n' +
          'a=ice-pwd:' + ICEPWD + '\r\n' +
          'a=fingerprint:sha-256 ' + FINGERPRINT_SHA256 + '\r\n' +
          'a=setup:actpass\r\n' +
          'a=mid:audio1\r\n' +
          'a=sendonly\r\n' +
          'a=rtcp-mux\r\n' +
          'a=rtcp-rsize\r\n' +
          'a=rtpmap:111 opus/48000/2\r\n' +
          'a=ssrc:2002 msid:stream2 track2\r\n' +
          'a=ssrc:2002 cname:some\r\n';
      it('disposes the second ice transport', (done) => {
        navigator.mediaDevices.getUserMedia({audio: true, video: true})
        .then((stream) => {
          // this creates two transceivers with ice transports.
          pc.addStream(stream);

          // this has bundle so will set usingBundle. But two
          // transceivers and their ice/dtls transports exist
          // and the second one needs to be disposed.
          return pc.setRemoteDescription({type: 'offer', sdp: sdp});
        })
        .then(() => {
          // the second ice transport should have been disposed.
          expect(pc.transceivers[0].iceTransport)
              .to.equal(pc.transceivers[1].iceTransport);
          done();
        });
      });
    });
```