### PR TITLE
Add eslint-config-google and fix eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "block-spacing": [2, "never"],
     "brace-style": [2, "1tbs", {"allowSingleLine": false}],
     "camelcase": [2, {"properties": "always"}],
+    "comma-style": 2,
     "curly": 2,
     "default-case": 2,
     "dot-notation": 2,
@@ -44,13 +45,19 @@
     "space-unary-ops": 2,
     "space-infix-ops": 2,
     "spaced-comment": 2,
-    "valid-typeof": 2
+    "valid-typeof": 2,
+    // ES6 and jsdoc rules that are disabled due to using the Google style guide.
+    "arrow-parens": 0,
+    "require-jsdoc": 0,
+    "no-var": 0,
+    "prefer-rest-params": 0,
+    "prefer-spread": 0,
   },
   "env": {
       "browser": true,
-      "node": true
+      "node": true,
   },
-  "extends": ["eslint:recommended", "webrtc"],
+  "extends": ["eslint:recommended", google],
   "globals": {
     "module": true,
     "require": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -52,6 +52,8 @@
     "no-var": 0,
     "prefer-rest-params": 0,
     "prefer-spread": 0,
+    // TODO: Fix errors on safari shim.
+    "no-invalid-this": 0,
   },
   "env": {
       "browser": true,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "chromedriver": "^2.29.0",
-    "eslint-config-webrtc": "^1.0.0",
+    "eslint": "^3.19.0",
+    "eslint-config-google": "^0.7.1",
     "faucet": "0.0.1",
     "geckodriver": "1.4.0",
     "grunt": "^0.4.5",

--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -22,7 +22,7 @@ module.exports = function(dependencies) {
   var adapter = {
     browserDetails: browserDetails,
     extractVersion: utils.extractVersion,
-    disableLog: utils.disableLog
+    disableLog: utils.disableLog,
   };
 
   // Uncomment the line below if you want logging to occur, including logging

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -65,7 +65,7 @@ var chromeShim = {
               this.dispatchEvent(event);
             }.bind(this));
           }.bind(this));
-        }
+        },
       });
     }
   },
@@ -133,7 +133,7 @@ var chromeShim = {
                 }
               }
               return this._dtmf;
-            }
+            },
           };
           pc._senders.push(sender);
           return sender;
@@ -155,7 +155,7 @@ var chromeShim = {
                 }
               }
               return this._dtmf;
-            }
+            },
           });
         });
       };
@@ -214,7 +214,7 @@ var chromeShim = {
               }
               self.src = URL.createObjectURL(stream);
             });
-          }
+          },
         });
       }
     }
@@ -243,7 +243,7 @@ var chromeShim = {
         Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
           get: function() {
             return window.webkitRTCPeerConnection.generateCertificate;
-          }
+          },
         });
       }
     } else {
@@ -273,7 +273,7 @@ var chromeShim = {
       Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
         get: function() {
           return OrigPeerConnection.generateCertificate;
-        }
+        },
       });
     }
 
@@ -305,8 +305,8 @@ var chromeShim = {
             timestamp: report.timestamp,
             type: {
               localcandidate: 'local-candidate',
-              remotecandidate: 'remote-candidate'
-            }[report.type] || report.type
+              remotecandidate: 'remote-candidate',
+            }[report.type] || report.type,
           };
           report.names().forEach(function(name) {
             standardStats[name] = report.stat(name);
@@ -411,7 +411,7 @@ var chromeShim = {
       }
       return nativeAddIceCandidate.apply(this, arguments);
     };
-  }
+  },
 };
 
 
@@ -422,5 +422,5 @@ module.exports = {
   shimGetSendersWithDtmf: chromeShim.shimGetSendersWithDtmf,
   shimSourceObject: chromeShim.shimSourceObject,
   shimPeerConnection: chromeShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia')
+  shimGetUserMedia: require('./getusermedia'),
 };

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -125,13 +125,13 @@ module.exports = function(window) {
       name: {
         ConstraintNotSatisfiedError: 'OverconstrainedError',
         PermissionDeniedError: 'NotAllowedError',
-        TrackStartError: 'NotReadableError'
+        TrackStartError: 'NotReadableError',
       }[e.name] || e.name,
       message: e.message,
       constraint: e.constraintName,
       toString: function() {
         return this.name + (this.message && ': ') + this.message;
-      }
+      },
     };
   };
 
@@ -171,9 +171,9 @@ module.exports = function(window) {
       getSupportedConstraints: function() {
         return {
           deviceId: true, echoCancellation: true, facingMode: true,
-          frameRate: true, height: true, width: true
+          frameRate: true, height: true, width: true,
         };
-      }
+      },
     };
   }
 

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -44,7 +44,7 @@ module.exports = {
             var ev = new Event('enabled');
             ev.enabled = value;
             this.dispatchEvent(ev);
-          }
+          },
         });
       }
     }
@@ -58,5 +58,5 @@ module.exports = {
       window.RTCRtpSender.prototype.replaceTrack =
           window.RTCRtpSender.prototype.setTrack;
     }
-  }
+  },
 };

--- a/src/js/edge/getusermedia.js
+++ b/src/js/edge/getusermedia.js
@@ -19,7 +19,7 @@ module.exports = function(window) {
       constraint: e.constraint,
       toString: function() {
         return this.name;
-      }
+      },
     };
   };
 

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -75,7 +75,7 @@ function getCommonCapabilities(localCapabilities, remoteCapabilities) {
   var commonCapabilities = {
     codecs: [],
     headerExtensions: [],
-    fecMechanisms: []
+    fecMechanisms: [],
   };
 
   var findCodecByPayloadType = function(pt, codecs) {
@@ -153,12 +153,12 @@ function isActionAllowedInSignalingState(action, type, signalingState) {
   return {
     offer: {
       setLocalDescription: ['stable', 'have-local-offer'],
-      setRemoteDescription: ['stable', 'have-remote-offer']
+      setRemoteDescription: ['stable', 'have-remote-offer'],
     },
     answer: {
       setLocalDescription: ['have-remote-offer', 'have-local-pranswer'],
-      setRemoteDescription: ['have-local-offer', 'have-remote-pranswer']
-    }
+      setRemoteDescription: ['have-local-offer', 'have-remote-pranswer'],
+    },
   }[type][action].indexOf(signalingState) !== -1;
 }
 
@@ -196,11 +196,11 @@ module.exports = function(window, edgeVersion) {
 
     this.localDescription = new window.RTCSessionDescription({
       type: '',
-      sdp: ''
+      sdp: '',
     });
     this.remoteDescription = new window.RTCSessionDescription({
       type: '',
-      sdp: ''
+      sdp: '',
     });
     this.signalingState = 'stable';
     this.iceConnectionState = 'new';
@@ -208,7 +208,7 @@ module.exports = function(window, edgeVersion) {
 
     this.iceOptions = {
       gatherPolicy: 'all',
-      iceServers: []
+      iceServers: [],
     };
     if (config && config.iceTransportPolicy) {
       switch (config.iceTransportPolicy) {
@@ -305,7 +305,7 @@ module.exports = function(window, edgeVersion) {
       sendEncodingParameters: null,
       recvEncodingParameters: null,
       stream: null,
-      wantReceive: true
+      wantReceive: true,
     };
     if (this.usingBundle && hasBundleTransport) {
       transceiver.iceTransport = this.transceivers[0].iceTransport;
@@ -493,7 +493,7 @@ module.exports = function(window, edgeVersion) {
 
     return {
       iceTransport: iceTransport,
-      dtlsTransport: dtlsTransport
+      dtlsTransport: dtlsTransport,
     };
   };
 
@@ -528,7 +528,7 @@ module.exports = function(window, edgeVersion) {
       params.encodings = transceiver.sendEncodingParameters;
       params.rtcp = {
         cname: SDPUtils.localCName,
-        compound: transceiver.rtcpParameters.compound
+        compound: transceiver.rtcpParameters.compound,
       };
       if (transceiver.recvEncodingParameters.length) {
         params.rtcp.ssrc = transceiver.recvEncodingParameters[0].ssrc;
@@ -547,7 +547,7 @@ module.exports = function(window, edgeVersion) {
       params.encodings = transceiver.recvEncodingParameters;
       params.rtcp = {
         cname: transceiver.rtcpParameters.cname,
-        compound: transceiver.rtcpParameters.compound
+        compound: transceiver.rtcpParameters.compound,
       };
       if (transceiver.sendEncodingParameters.length) {
         params.rtcp.ssrc = transceiver.sendEncodingParameters[0].ssrc;
@@ -633,7 +633,7 @@ module.exports = function(window, edgeVersion) {
 
     this.localDescription = {
       type: description.type,
-      sdp: description.sdp
+      sdp: description.sdp,
     };
     switch (description.type) {
       case 'offer':
@@ -724,7 +724,7 @@ module.exports = function(window, edgeVersion) {
       if (kind === 'application' && protocol === 'DTLS/SCTP') {
         self.transceivers[sdpMLineIndex] = {
           mid: mid,
-          isDatachannel: true
+          isDatachannel: true,
         };
         return;
       }
@@ -791,7 +791,7 @@ module.exports = function(window, edgeVersion) {
         }
 
         sendEncodingParameters = [{
-          ssrc: (2 * sdpMLineIndex + 2) * 1001
+          ssrc: (2 * sdpMLineIndex + 2) * 1001,
         }];
 
         if (direction === 'sendrecv' || direction === 'sendonly') {
@@ -806,13 +806,13 @@ module.exports = function(window, edgeVersion) {
               Object.defineProperty(streams[remoteMsid.stream], 'id', {
                 get: function() {
                   return remoteMsid.stream;
-                }
+                },
               });
             }
             Object.defineProperty(track, 'id', {
               get: function() {
                 return remoteMsid.track;
-              }
+              },
             });
             streams[remoteMsid.stream].addTrack(track);
             receiverList.push([track, rtpReceiver,
@@ -908,7 +908,7 @@ module.exports = function(window, edgeVersion) {
 
     this.remoteDescription = {
       type: description.type,
-      sdp: description.sdp
+      sdp: description.sdp,
     };
     switch (description.type) {
       case 'offer':
@@ -1037,12 +1037,12 @@ module.exports = function(window, edgeVersion) {
     var newState;
     var states = {
       'new': 0,
-      closed: 0,
-      connecting: 0,
-      checking: 0,
-      connected: 0,
-      completed: 0,
-      failed: 0
+      'closed': 0,
+      'connecting': 0,
+      'checking': 0,
+      'connected': 0,
+      'completed': 0,
+      'failed': 0,
     };
     this.transceivers.forEach(function(transceiver) {
       states[transceiver.iceTransport.state]++;
@@ -1183,13 +1183,13 @@ module.exports = function(window, edgeVersion) {
 
       // generate an ssrc now, to be used later in rtpSender.send
       var sendEncodingParameters = [{
-        ssrc: (2 * sdpMLineIndex + 1) * 1001
+        ssrc: (2 * sdpMLineIndex + 1) * 1001,
       }];
       if (track) {
         // add RTX
         if (edgeVersion >= 15019 && kind === 'video') {
           sendEncodingParameters[0].rtx = {
-            ssrc: (2 * sdpMLineIndex + 1) * 1001 + 1
+            ssrc: (2 * sdpMLineIndex + 1) * 1001 + 1,
           };
         }
       }
@@ -1222,7 +1222,7 @@ module.exports = function(window, edgeVersion) {
     this._pendingOffer = transceivers;
     var desc = new window.RTCSessionDescription({
       type: 'offer',
-      sdp: sdp
+      sdp: sdp,
     });
     if (arguments.length && typeof arguments[0] === 'function') {
       window.setTimeout(arguments[0], 0, desc);
@@ -1257,7 +1257,7 @@ module.exports = function(window, edgeVersion) {
           // add RTX
           if (edgeVersion >= 15019 && transceiver.kind === 'video') {
             transceiver.sendEncodingParameters[0].rtx = {
-              ssrc: (2 * sdpMLineIndex + 2) * 1001 + 1
+              ssrc: (2 * sdpMLineIndex + 2) * 1001 + 1,
             };
           }
         }
@@ -1285,7 +1285,7 @@ module.exports = function(window, edgeVersion) {
 
     var desc = new window.RTCSessionDescription({
       type: 'answer',
-      sdp: sdp
+      sdp: sdp,
     });
     if (arguments.length && typeof arguments[0] === 'function') {
       window.setTimeout(arguments[0], 0, desc);
@@ -1357,7 +1357,7 @@ module.exports = function(window, edgeVersion) {
         outboundrtp: 'outbound-rtp',
         candidatepair: 'candidate-pair',
         localcandidate: 'local-candidate',
-        remotecandidate: 'remote-candidate'
+        remotecandidate: 'remote-candidate',
       }[stat.type] || stat.type;
     };
     return new Promise(function(resolve) {

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -33,7 +33,7 @@ var firefoxShim = {
               this.dispatchEvent(event);
             }.bind(this));
           }.bind(this));
-        }
+        },
       });
     }
   },
@@ -50,7 +50,7 @@ var firefoxShim = {
           },
           set: function(stream) {
             this.mozSrcObject = stream;
-          }
+          },
         });
       }
     }
@@ -76,7 +76,7 @@ var firefoxShim = {
               if (server.hasOwnProperty('urls')) {
                 for (var j = 0; j < server.urls.length; j++) {
                   var newServer = {
-                    url: server.urls[j]
+                    url: server.urls[j],
                   };
                   if (server.urls[j].indexOf('turn') === 0) {
                     newServer.username = server.username;
@@ -101,7 +101,7 @@ var firefoxShim = {
         Object.defineProperty(window.RTCPeerConnection, 'generateCertificate', {
           get: function() {
             return window.mozRTCPeerConnection.generateCertificate;
-          }
+          },
         });
       }
 
@@ -149,7 +149,7 @@ var firefoxShim = {
       outboundrtp: 'outbound-rtp',
       candidatepair: 'candidate-pair',
       localcandidate: 'local-candidate',
-      remotecandidate: 'remote-candidate'
+      remotecandidate: 'remote-candidate',
     };
 
     var nativeGetStats = window.RTCPeerConnection.prototype.getStats;
@@ -177,7 +177,7 @@ var firefoxShim = {
               // Avoid TypeError: "type" is read-only, in old versions. 34-43ish
               stats.forEach(function(stat, i) {
                 stats.set(i, Object.assign({}, stat, {
-                  type: modernStatsTypes[stat.type] || stat.type
+                  type: modernStatsTypes[stat.type] || stat.type,
                 }));
               });
             }
@@ -186,7 +186,7 @@ var firefoxShim = {
         })
         .then(onSucc, onErr);
     };
-  }
+  },
 };
 
 // Expose public methods.
@@ -194,5 +194,5 @@ module.exports = {
   shimOnTrack: firefoxShim.shimOnTrack,
   shimSourceObject: firefoxShim.shimSourceObject,
   shimPeerConnection: firefoxShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia')
+  shimGetUserMedia: require('./getusermedia'),
 };

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -22,16 +22,16 @@ module.exports = function(window) {
         InternalError: 'NotReadableError',
         NotSupportedError: 'TypeError',
         PermissionDeniedError: 'NotAllowedError',
-        SecurityError: 'NotAllowedError'
+        SecurityError: 'NotAllowedError',
       }[e.name] || e.name,
       message: {
         'The operation is insecure.': 'The request is not allowed by the ' +
-        'user agent or the platform in the current context.'
+        'user agent or the platform in the current context.',
       }[e.message] || e.message,
       constraint: e.constraint,
       toString: function() {
         return this.name + (this.message && ': ') + this.message;
-      }
+      },
     };
   };
 
@@ -107,7 +107,7 @@ module.exports = function(window) {
   if (!navigator.mediaDevices) {
     navigator.mediaDevices = {getUserMedia: getUserMediaPromise_,
       addEventListener: function() { },
-      removeEventListener: function() { }
+      removeEventListener: function() { },
     };
   }
   navigator.mediaDevices.enumerateDevices =
@@ -115,7 +115,7 @@ module.exports = function(window) {
         return new Promise(function(resolve) {
           var infos = [
             {kind: 'audioinput', deviceId: 'default', label: '', groupId: ''},
-            {kind: 'videoinput', deviceId: 'default', label: '', groupId: ''}
+            {kind: 'videoinput', deviceId: 'default', label: '', groupId: ''},
           ];
           resolve(infos);
         });

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -50,7 +50,7 @@ var safariShim = {
             event.stream = e.streams[0];
             this.dispatchEvent(event);
           }.bind(this));
-        }
+        },
       });
     }
   },
@@ -126,10 +126,10 @@ var safariShim = {
         navigator.getUserMedia = function(constraints, cb, errcb) {
           navigator.mediaDevices.getUserMedia(constraints)
           .then(cb, errcb);
-        }.bind(navigator);
+        };
       }
     }
-  }
+  },
 };
 
 // Expose public methods.
@@ -137,7 +137,7 @@ module.exports = {
   shimCallbacksAPI: safariShim.shimCallbacksAPI,
   shimAddStream: safariShim.shimAddStream,
   shimOnAddStream: safariShim.shimOnAddStream,
-  shimGetUserMedia: safariShim.shimGetUserMedia
+  shimGetUserMedia: safariShim.shimGetUserMedia,
   // TODO
   // shimPeerConnection: safariShim.shimPeerConnection
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -22,13 +22,13 @@ var utils = {
         'adapter.js logging enabled';
   },
 
-  log: function() {
+  log: function(args) {
     if (typeof window === 'object') {
       if (logDisabled_) {
         return;
       }
       if (typeof console !== 'undefined' && typeof console.log === 'function') {
-        console.log.apply(console, arguments);
+        console.log.apply(console, args);
       }
     }
   },
@@ -120,7 +120,8 @@ var utils = {
 
     var nativeCreateObjectURL = URL.createObjectURL.bind(URL);
     var nativeRevokeObjectURL = URL.revokeObjectURL.bind(URL);
-    var streams = new Map(), newId = 0;
+    var streams = new Map();
+    var newId = 0;
 
     URL.createObjectURL = function(stream) {
       if ('getTracks' in stream) {
@@ -146,7 +147,7 @@ var utils = {
       set: function(url) {
         this.srcObject = streams.get(url) || null;
         return dsc.set.apply(this, [url]);
-      }
+      },
     });
 
     var nativeSetAttribute = window.HTMLMediaElement.prototype.setAttribute;
@@ -157,7 +158,7 @@ var utils = {
       }
       return nativeSetAttribute.apply(this, arguments);
     };
-  }
+  },
 };
 
 // Export.
@@ -166,5 +167,5 @@ module.exports = {
   disableLog: utils.disableLog,
   extractVersion: utils.extractVersion,
   shimCreateObjectURL: utils.shimCreateObjectURL,
-  detectBrowser: utils.detectBrowser.bind(utils)
+  detectBrowser: utils.detectBrowser.bind(utils),
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -46,9 +46,9 @@ var utils = {
     return match && match.length >= pos && parseInt(match[pos], 10);
   },
 
-  /**
+/**
    * Browser detector.
-   *
+   * @param {object} window global window object
    * @return {object} result containing browser and version
    *     properties.
    */

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,5 +3,10 @@
         "node": true,
         "es6": true
     },
-    "rules": {}
+    "rules": {
+      "arrow-parens": 2,
+      "no-var": 2,
+      "prefer-rest-params": 2,
+      "prefer-spread": 2,
+    }
 }

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -8,9 +8,9 @@
  /* eslint-env node */
 
 'use strict';
-var fs = require('fs');
-var os = require('os');
-var test = require('tape');
+let fs = require('fs');
+let os = require('os');
+let test = require('tape');
 
 if (!process.env.BROWSER) {
   process.env.BROWSER = 'chrome';
@@ -18,7 +18,7 @@ if (!process.env.BROWSER) {
 if (!process.env.BVER) {
   process.env.BVER = 'stable';
 }
-var browserbin = './browsers/bin/' + process.env.BROWSER +
+let browserbin = './browsers/bin/' + process.env.BROWSER +
     '-' + process.env.BVER;
 
 // install browsers via travis-multirunner (on Linux).
@@ -54,7 +54,7 @@ require('./test');
 // This is run as a test so it is executed after all tests
 // have completed.
 test('Shutdown', function(t) {
-  var driver = require('./selenium-lib').buildDriver();
+  let driver = require('./selenium-lib').buildDriver();
   driver.close()
   .then(function() {
     driver.quit().then(function() {

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -9,27 +9,27 @@
 'use strict';
 
 // https://code.google.com/p/selenium/wiki/WebDriverJs
-var webdriver = require('selenium-webdriver');
-var chrome = require('selenium-webdriver/chrome');
-var firefox = require('selenium-webdriver/firefox');
-var edge = require('selenium-webdriver/edge');
-var fs = require('fs');
-var os = require('os');
+let webdriver = require('selenium-webdriver');
+let chrome = require('selenium-webdriver/chrome');
+let firefox = require('selenium-webdriver/firefox');
+let edge = require('selenium-webdriver/edge');
+let fs = require('fs');
+let os = require('os');
 
-var sharedDriver = null;
+let sharedDriver = null;
 
 function getBrowserVersion() {
-  var browser = process.env.BROWSER;
-  var browserChannel = process.env.BVER;
-  var symlink = './browsers/bin/' + browser + '-' + browserChannel;
-  var path = fs.readlinkSync(symlink);
+  let browser = process.env.BROWSER;
+  let browserChannel = process.env.BVER;
+  let symlink = './browsers/bin/' + browser + '-' + browserChannel;
+  let path = fs.readlinkSync(symlink);
 
   // Browser reg expressions and position to look for the milestone version.
-  var chromeExp = /\/chrome\/(\d+)\./;
-  var firefoxExp = /\/firefox\/(\d+)\./;
+  let chromeExp = /\/chrome\/(\d+)\./;
+  let firefoxExp = /\/firefox\/(\d+)\./;
 
-  var browserVersion = function(pathToBrowser, expr) {
-    var match = pathToBrowser.match(expr);
+  let browserVersion = function(pathToBrowser, expr) {
+    let match = pathToBrowser.match(expr);
     return match && match.length >= 1 && parseInt(match[1], 10);
   };
 
@@ -49,7 +49,7 @@ function buildDriver() {
   }
   // Firefox options.
   // http://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_firefox.html
-  var profile = new firefox.Profile();
+  let profile = new firefox.Profile();
   profile.setPreference('media.navigator.streams.fake', true);
   // This enables device labels for enumerateDevices when using fake devices.
   profile.setPreference('media.navigator.permission.disabled', true);
@@ -60,7 +60,7 @@ function buildDriver() {
   // https://github.com/SeleniumHQ/selenium/issues/901.
   profile.setPreference('xpinstall.signatures.required', false);
 
-  var firefoxOptions = new firefox.Options()
+  let firefoxOptions = new firefox.Options()
       .setProfile(profile);
   if (os.platform() === 'linux') {
     firefoxOptions.setBinary('node_modules/.bin/start-firefox');
@@ -68,7 +68,7 @@ function buildDriver() {
 
   // Chrome options.
   // http://selenium.googlecode.com/git/docs/api/javascript/module_selenium-webdriver_chrome_class_Options.html#addArguments
-  var chromeOptions = new chrome.Options()
+  let chromeOptions = new chrome.Options()
       .addArguments('allow-file-access-from-files')
       .addArguments('use-fake-device-for-media-stream')
       .addArguments('use-fake-ui-for-media-stream');
@@ -87,7 +87,7 @@ function buildDriver() {
     chromeOptions.addArguments('disable-gpu');
   }
 
-  var edgeOptions = new edge.Options();
+  let edgeOptions = new edge.Options();
 
   sharedDriver = new webdriver.Builder()
       .forBrowser(process.env.BROWSER)
@@ -140,5 +140,5 @@ module.exports = {
   buildDriver,
   loadTestPage,
   getBrowserVersion,
-  getStats
+  getStats,
 };

--- a/test/test.js
+++ b/test/test.js
@@ -345,7 +345,7 @@ test('Audio srcObject getter/setter test', function(t) {
       webdriver.By.id('audio')), 3000);
   })
   .then(function() {
-    return driver.executafeScript(
+    return driver.executeScript(
         'return document.getElementById(\'audio\').srcObject.id')
     .then(function(srcObjectId) {
       driver.executeScript('return window.stream.id')

--- a/test/test.js
+++ b/test/test.js
@@ -12,14 +12,14 @@
 // This is a basic test file for use with testling and webdriver.
 // The test script language comes from tape.
 
-var test = require('tape');
-var webdriver = require('selenium-webdriver');
-var seleniumHelpers = require('./selenium-lib');
+let test = require('tape');
+let webdriver = require('selenium-webdriver');
+let seleniumHelpers = require('./selenium-lib');
 const browserVersion = seleniumHelpers.getBrowserVersion();
 
 // Start of tests.
 test('Browser identified', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -38,7 +38,7 @@ test('Browser identified', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -47,11 +47,11 @@ test('Browser identified', function(t) {
 
 // Test that getUserMedia is shimmed properly.
 test('navigator.mediaDevices.getUserMedia', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
     navigator.mediaDevices.getUserMedia({video: true, fake: true})
     .then(function(stream) {
       window.stream = stream;
@@ -69,7 +69,7 @@ test('navigator.mediaDevices.getUserMedia', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Make sure we get a stream before continuing.
     driver.wait(function() {
@@ -90,7 +90,7 @@ test('navigator.mediaDevices.getUserMedia', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -98,7 +98,7 @@ test('navigator.mediaDevices.getUserMedia', function(t) {
 });
 
 test('getUserMedia shim', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -119,7 +119,7 @@ test('getUserMedia shim', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -130,7 +130,7 @@ test('getUserMedia shim', function(t) {
 // is possible. The usecase for this is the devicechanged event.
 // This does not test whether devicechanged is actually called.
 test('navigator.mediaDevices eventlisteners', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -156,7 +156,7 @@ test('navigator.mediaDevices eventlisteners', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -164,7 +164,7 @@ test('navigator.mediaDevices eventlisteners', function(t) {
 });
 
 test('MediaStream shim', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -184,7 +184,7 @@ test('MediaStream shim', function(t) {
 });
 
 test('RTCPeerConnection shim', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -215,7 +215,7 @@ test('RTCPeerConnection shim', function(t) {
 });
 
 test('Create RTCPeerConnection', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -231,7 +231,7 @@ test('Create RTCPeerConnection', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -239,18 +239,18 @@ test('Create RTCPeerConnection', function(t) {
 });
 
 test('Video srcObject getter/setter test', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var video = document.createElement('video');
+      let video = document.createElement('video');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       video.srcObject = stream;
@@ -274,7 +274,7 @@ test('Video srcObject getter/setter test', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Wait until loadedmetadata event has fired and appended video element.
     return driver.wait(webdriver.until.elementLocated(
@@ -295,7 +295,7 @@ test('Video srcObject getter/setter test', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -303,18 +303,18 @@ test('Video srcObject getter/setter test', function(t) {
 });
 
 test('Audio srcObject getter/setter test', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: false, audio: true, fake: true};
+    let constraints = {video: false, audio: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var audio = document.createElement('audio');
+      let audio = document.createElement('audio');
       audio.setAttribute('id', 'audio');
       audio.srcObject = stream;
       // If the srcObject shim works, we should get a video
@@ -337,7 +337,7 @@ test('Audio srcObject getter/setter test', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Wait until loadedmetadata event has fired and appended video element.
     // 5 second timeout in case the event does not fire for some reason.
@@ -345,7 +345,7 @@ test('Audio srcObject getter/setter test', function(t) {
       webdriver.By.id('audio')), 3000);
   })
   .then(function() {
-    return driver.executeScript(
+    return driver.executafeScript(
         'return document.getElementById(\'audio\').srcObject.id')
     .then(function(srcObjectId) {
       driver.executeScript('return window.stream.id')
@@ -359,7 +359,7 @@ test('Audio srcObject getter/setter test', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -367,20 +367,20 @@ test('Audio srcObject getter/setter test', function(t) {
 });
 
 test('createObjectURL shim test', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
     ['audio', 'video'].reduce(function(p, type) {
       return p.then(function() {
-        var constraints = {fake: true};
+        let constraints = {fake: true};
         constraints[type] = true;
         return navigator.mediaDevices.getUserMedia(constraints);
       })
       .then(function(stream) {
-        var element = document.createElement(type);
+        let element = document.createElement(type);
         window[type] = element;
         window[type + 'Stream'] = stream;
         element.id = type;
@@ -414,7 +414,7 @@ test('createObjectURL shim test', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = error ? 'error: ' + error : 'no errors';
+    let gumResult = error ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Wait until loadedmetadata event has fired and appended video element.
     return driver.wait(webdriver.until.elementLocated(
@@ -425,7 +425,7 @@ test('createObjectURL shim test', function(t) {
       'return document.getElementById("audio").srcObject.id',
       'return window.audioStream.id',
       'return document.getElementById("video").srcObject.id',
-      'return window.videoStream.id'
+      'return window.videoStream.id',
     ].map(function(script) {
       return driver.executeScript(script);
     }))
@@ -437,7 +437,7 @@ test('createObjectURL shim test', function(t) {
     });
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -445,19 +445,19 @@ test('createObjectURL shim test', function(t) {
 });
 
 test('srcObject set from another object', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var video = document.createElement('video');
-      var video2 = document.createElement('video2');
+      let video = document.createElement('video');
+      let video2 = document.createElement('video2');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       video2.setAttribute('id', 'video2');
@@ -486,7 +486,7 @@ test('srcObject set from another object', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Wait until loadedmetadata event has fired and appended video element.
     // 5 second timeout in case the event does not fire for some reason.
@@ -509,7 +509,7 @@ test('srcObject set from another object', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -517,18 +517,18 @@ test('srcObject set from another object', function(t) {
 });
 
 test('srcObject null setter', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var video = document.createElement('video');
+      let video = document.createElement('video');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       document.body.appendChild(video);
@@ -550,7 +550,7 @@ test('srcObject null setter', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // Wait until loadedmetadata event has fired and appended video element.
     // 5 second timeout in case the event does not fire for some reason.
@@ -570,7 +570,7 @@ test('srcObject null setter', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -578,18 +578,18 @@ test('srcObject null setter', function(t) {
 });
 
 test('Attach mediaStream directly', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var video = document.createElement('video');
+      let video = document.createElement('video');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       // If the srcObject shim works, we should get a video
@@ -616,7 +616,7 @@ test('Attach mediaStream directly', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // We need to wait due to the stream can take a while to setup.
     driver.wait(function() {
@@ -645,7 +645,7 @@ test('Attach mediaStream directly', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -653,19 +653,19 @@ test('Attach mediaStream directly', function(t) {
 });
 
 test('Re-attaching mediaStream directly', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       window.stream = stream;
 
-      var video = document.createElement('video');
-      var video2 = document.createElement('video');
+      let video = document.createElement('video');
+      let video2 = document.createElement('video');
       video.setAttribute('id', 'video');
       video.setAttribute('autoplay', 'true');
       video2.setAttribute('id', 'video2');
@@ -698,7 +698,7 @@ test('Re-attaching mediaStream directly', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var gumResult = (error) ? 'error: ' + error : 'no errors';
+    let gumResult = (error) ? 'error: ' + error : 'no errors';
     t.ok(!error, 'getUserMedia result:  ' + gumResult);
     // We need to wait due to the stream can take a while to setup.
     return driver.wait(function() {
@@ -742,7 +742,7 @@ test('Re-attaching mediaStream directly', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -753,18 +753,18 @@ test('Re-attaching mediaStream directly', function(t) {
 test('Call getUserMedia with impossible constraints',
     {skip: process.env.BROWSER === 'chrome'},
     function(t) {
-      var driver = seleniumHelpers.buildDriver();
+      let driver = seleniumHelpers.buildDriver();
 
       // Define test.
-      var testDefinition = function() {
-        var callback = arguments[arguments.length - 1];
+      let testDefinition = function(...args) {
+        let callback = args[args.length - 1];
 
-        var impossibleConstraints = {
+        let impossibleConstraints = {
           video: {
             width: 1280,
             height: {min: 200, ideal: 720, max: 1080},
-            frameRate: {exact: 0} // to fail
-          }
+            frameRate: {exact: 0}, // to fail
+          },
         };
         // TODO: Remove when firefox 42+ accepts impossible constraints
         // on fake devices.
@@ -793,7 +793,7 @@ test('Call getUserMedia with impossible constraints',
       .then(function(isFirefoxAndVersionLessThan42) {
         if (isFirefoxAndVersionLessThan42) {
           t.skip('getUserMedia(impossibleConstraints) not supported on < 42');
-          throw 'skip-test';
+          throw new Error('skip-test');
         }
         return driver.executeAsyncScript(testDefinition);
       })
@@ -804,7 +804,7 @@ test('Call getUserMedia with impossible constraints',
         t.end();
       })
       .then(null, function(err) {
-        if (err !== 'skip-test') {
+        if (err.message !== 'skip-test') {
           t.fail(err);
         }
         t.end();
@@ -812,15 +812,15 @@ test('Call getUserMedia with impossible constraints',
     });
 
 test('Basic connection establishment', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -832,10 +832,10 @@ test('Basic connection establishment', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -844,7 +844,7 @@ test('Basic connection establishment', function(t) {
       }
     };
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       pc.addIceCandidate(event.candidate,
         function() {
           // TODO: Decide if we are interested in adding all candidates
@@ -863,7 +863,7 @@ test('Basic connection establishment', function(t) {
       addCandidate(pc1, event);
     };
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
@@ -938,10 +938,10 @@ test('Basic connection establishment', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -950,7 +950,7 @@ test('Basic connection establishment', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -958,15 +958,15 @@ test('Basic connection establishment', function(t) {
 });
 
 test('Basic connection establishment with promise', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -978,10 +978,10 @@ test('Basic connection establishment with promise', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -990,9 +990,9 @@ test('Basic connection establishment with promise', function(t) {
       }
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1012,7 +1012,7 @@ test('Basic connection establishment with promise', function(t) {
       addCandidate(pc1, event);
     };
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
@@ -1064,10 +1064,10 @@ test('Basic connection establishment with promise', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1076,7 +1076,7 @@ test('Basic connection establishment with promise', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1084,15 +1084,15 @@ test('Basic connection establishment with promise', function(t) {
 });
 
 test('Basic connection establishment with bidirectional streams', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1104,10 +1104,10 @@ test('Basic connection establishment with bidirectional streams', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -1116,9 +1116,9 @@ test('Basic connection establishment with bidirectional streams', function(t) {
       }
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1138,7 +1138,7 @@ test('Basic connection establishment with bidirectional streams', function(t) {
       addCandidate(pc1, event);
     };
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
@@ -1191,10 +1191,10 @@ test('Basic connection establishment with bidirectional streams', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1203,7 +1203,7 @@ test('Basic connection establishment with bidirectional streams', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1211,15 +1211,15 @@ test('Basic connection establishment with bidirectional streams', function(t) {
 });
 
 test('Basic connection establishment with addTrack', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1231,10 +1231,10 @@ test('Basic connection establishment with addTrack', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -1249,9 +1249,9 @@ test('Basic connection establishment with addTrack', function(t) {
       tc.ok(event.stream.getVideoTracks().length === 1, 'with a video track');
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1271,7 +1271,7 @@ test('Basic connection establishment with addTrack', function(t) {
       addCandidate(pc1, event);
     };
 
-    var constraints = {audio: true, video: true, fake: true};
+    let constraints = {audio: true, video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       stream.getTracks().forEach(function(track) {
@@ -1325,10 +1325,10 @@ test('Basic connection establishment with addTrack', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1337,7 +1337,7 @@ test('Basic connection establishment with addTrack', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1346,15 +1346,15 @@ test('Basic connection establishment with addTrack', function(t) {
 
 test('Basic connection establishment with addTrack ' +
     'and only the audio track of an av stream', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1366,10 +1366,10 @@ test('Basic connection establishment with addTrack ' +
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -1384,9 +1384,9 @@ test('Basic connection establishment with addTrack ' +
       tc.ok(event.stream.getVideoTracks().length === 0, 'with no video track');
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1406,7 +1406,7 @@ test('Basic connection establishment with addTrack ' +
       addCandidate(pc1, event);
     };
 
-    var constraints = {audio: true, video: true, fake: true};
+    let constraints = {audio: true, video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       stream.getAudioTracks().forEach(function(track) {
@@ -1460,10 +1460,10 @@ test('Basic connection establishment with addTrack ' +
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1472,7 +1472,7 @@ test('Basic connection establishment with addTrack ' +
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1481,15 +1481,15 @@ test('Basic connection establishment with addTrack ' +
 
 test('Basic connection establishment with addTrack ' +
     'and two streams', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1501,11 +1501,11 @@ test('Basic connection establishment with addTrack ' +
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
-    var remoteStreams = 0;
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
+    let remoteStreams = 0;
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -1518,9 +1518,9 @@ test('Basic connection establishment with addTrack ' +
       tc.pass('onaddstream called ' + remoteStreams++);
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1540,11 +1540,11 @@ test('Basic connection establishment with addTrack ' +
       addCandidate(pc1, event);
     };
 
-    var constraints = {audio: true, video: true, fake: true};
+    let constraints = {audio: true, video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
-      var audioStream = new MediaStream(stream.getAudioTracks());
-      var videoStream = new MediaStream(stream.getVideoTracks());
+      let audioStream = new MediaStream(stream.getAudioTracks());
+      let videoStream = new MediaStream(stream.getVideoTracks());
       audioStream.getTracks().forEach(function(track) {
         pc1.addTrack(track, audioStream);
       });
@@ -1600,10 +1600,10 @@ test('Basic connection establishment with addTrack ' +
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1612,7 +1612,7 @@ test('Basic connection establishment with addTrack ' +
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1621,15 +1621,15 @@ test('Basic connection establishment with addTrack ' +
 
 test('Basic connection establishment with promise but no' +
     'end-of-candidates', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1641,10 +1641,10 @@ test('Basic connection establishment with promise but no' +
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc1.oniceconnectionstatechange = function() {
       if (pc1.iceConnectionState === 'connected' ||
@@ -1653,9 +1653,9 @@ test('Basic connection establishment with promise but no' +
       }
     };
 
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1679,7 +1679,7 @@ test('Basic connection establishment with promise but no' +
       }
     };
 
-    var constraints = {video: true, fake: true};
+    let constraints = {video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
@@ -1731,10 +1731,10 @@ test('Basic connection establishment with promise but no' +
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1743,7 +1743,7 @@ test('Basic connection establishment with promise but no' +
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1751,15 +1751,15 @@ test('Basic connection establishment with promise but no' +
 });
 
 test('Basic connection establishment with datachannel', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1771,10 +1771,10 @@ test('Basic connection establishment with datachannel', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     if (typeof pc1.createDataChannel !== 'function') {
       callback('DataChannel is not supported');
@@ -1788,7 +1788,7 @@ test('Basic connection establishment with datachannel', function(t) {
       }
     };
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       pc.addIceCandidate(event.candidate).then(function() {
         // TODO: Decide if we are interested in adding all candidates
         // as passed tests.
@@ -1839,7 +1839,7 @@ test('Basic connection establishment with datachannel', function(t) {
     // or pc1ConnectionStatus.
     if (callback === 'DataChannel is not supported') {
       t.skip(callback);
-      throw 'skip-test';
+      throw new Error('skip-test');
     }
     return callback;
   })
@@ -1850,10 +1850,10 @@ test('Basic connection establishment with datachannel', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1862,7 +1862,7 @@ test('Basic connection establishment with datachannel', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -1870,15 +1870,15 @@ test('Basic connection establishment with datachannel', function(t) {
 });
 
 test('video loadedmetadata is called for a video call', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var counter = 1;
+    let counter = 1;
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -1890,13 +1890,13 @@ test('video loadedmetadata is called for a video call', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
     pc2.addEventListener('addstream', function(e) {
-      var v = document.createElement('video');
+      let v = document.createElement('video');
       v.autoplay = true;
       v.addEventListener('loadedmetadata', function() {
         tc.pass('loadedmetadata');
@@ -1904,9 +1904,9 @@ test('video loadedmetadata is called for a video call', function(t) {
       });
       v.srcObject = e.stream;
     });
-    var dictionary = obj => JSON.parse(JSON.stringify(obj));
+    let dictionary = (obj) => JSON.parse(JSON.stringify(obj));
 
-    var addCandidate = function(pc, event) {
+    let addCandidate = function(pc, event) {
       if (event.candidate) {
         event.candidate = dictionary(event.candidate);
       }
@@ -1926,7 +1926,7 @@ test('video loadedmetadata is called for a video call', function(t) {
       addCandidate(pc1, event);
     };
 
-    var constraints = {audio: true, video: true, fake: true};
+    let constraints = {audio: true, video: true, fake: true};
     navigator.mediaDevices.getUserMedia(constraints)
     .then(function(stream) {
       pc1.addStream(stream);
@@ -1972,10 +1972,10 @@ test('video loadedmetadata is called for a video call', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -1984,45 +1984,45 @@ test('video loadedmetadata is called for a video call', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
   });
 });
 
-test('dtmf', t => {
-  var driver = seleniumHelpers.buildDriver();
+test('dtmf', (t) => {
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var pc1 = new RTCPeerConnection(null);
-    var pc2 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
+    let pc2 = new RTCPeerConnection(null);
 
-    pc1.onicecandidate = e => pc2.addIceCandidate(e.candidate);
-    pc2.onicecandidate = e => pc1.addIceCandidate(e.candidate);
-    pc1.onnegotiationneeded = e => pc1.createOffer()
-      .then(offer => pc1.setLocalDescription(offer))
+    pc1.onicecandidate = (e) => pc2.addIceCandidate(e.candidate);
+    pc2.onicecandidate = (e) => pc1.addIceCandidate(e.candidate);
+    pc1.onnegotiationneeded = (e) => pc1.createOffer()
+      .then((offer) => pc1.setLocalDescription(offer))
       .then(() => pc2.setRemoteDescription(pc1.localDescription))
       .then(() => pc2.createAnswer())
-      .then(answer => pc2.setLocalDescription(answer))
+      .then((answer) => pc2.setLocalDescription(answer))
       .then(() => pc1.setRemoteDescription(pc2.localDescription));
 
     navigator.mediaDevices.getUserMedia({audio: true})
-    .then(stream => {
+    .then((stream) => {
       pc1.addStream(stream);
-      return new Promise(resolve => pc1.oniceconnectionstatechange =
-        e => pc1.iceConnectionState === 'connected' && resolve())
+      return new Promise((resolve) => pc1.oniceconnectionstatechange =
+        (e) => pc1.iceConnectionState === 'connected' && resolve())
       .then(() => {
-        let sender = pc1.getSenders().find(s => s.track.kind === 'audio');
+        let sender = pc1.getSenders().find((s) => s.track.kind === 'audio');
         if (!sender.dtmf) {
-          throw 'skip-test';
+          throw new Error('skip-test');
         }
         sender.dtmf.insertDTMF('1');
-        return new Promise(resolve => sender.dtmf.ontonechange = resolve);
+        return new Promise((resolve) => sender.dtmf.ontonechange = resolve);
       })
-      .then(e => {
+      .then((e) => {
         // Test getSenders Chrome polyfill
         try {
           // FF51+ doesn't have removeStream
@@ -2035,10 +2035,10 @@ test('dtmf', t => {
           if (err.name !== 'NotSupportedError') {
             throw err;
           }
-          pc1.getSenders().forEach(sender => pc1.removeTrack(sender));
+          pc1.getSenders().forEach((sender) => pc1.removeTrack(sender));
         }
-        stream.getTracks().forEach(track => {
-          let sender = pc1.getSenders().find(s => s.track === track);
+        stream.getTracks().forEach((track) => {
+          let sender = pc1.getSenders().find((s) => s.track === track);
           if (sender) {
             throw new Error('sender was not removed when it should have been');
           }
@@ -2046,8 +2046,8 @@ test('dtmf', t => {
         return e.tone;
       });
     })
-    .then(tone => callback({tone: tone}),
-          err => callback({error: err.toString()}));
+    .then((tone) => callback({tone: tone}),
+          (err) => callback({error: err.toString()}));
   };
 
   // Run test.
@@ -2066,17 +2066,17 @@ test('dtmf', t => {
     }
     t.is(tone, '1', 'DTMF sent');
   })
-  .then(null, err => t.fail(err))
+  .then(null, (err) => t.fail(err))
   .then(() => t.end());
 });
 
 test('addIceCandidate with null', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var pc1 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
     pc1.addIceCandidate(null)
     // callback is called with either the empty result
     // of the .then or the error from .catch.
@@ -2094,7 +2094,7 @@ test('addIceCandidate with null', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2102,12 +2102,12 @@ test('addIceCandidate with null', function(t) {
 });
 
 test('addIceCandidate with undefined', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var pc1 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
     pc1.addIceCandidate(undefined)
     // callback is called with either the empty result
     // of the .then or the error from .catch.
@@ -2125,7 +2125,7 @@ test('addIceCandidate with undefined', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2133,10 +2133,10 @@ test('addIceCandidate with undefined', function(t) {
 });
 
 test('call enumerateDevices', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
     navigator.mediaDevices.enumerateDevices()
     .then(function(devices) {
@@ -2175,7 +2175,7 @@ test('call enumerateDevices', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2184,13 +2184,13 @@ test('call enumerateDevices', function(t) {
 
 // Test polyfill for getStats.
 test('getStats', {skip: true}, function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
     window.testsEqualArray = [];
-    var pc1 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
 
     // Test expected new behavior.
     new Promise(function(resolve, reject) {
@@ -2207,7 +2207,7 @@ test('getStats', {skip: true}, function(t) {
     })
     .then(function(report) {
       // Test legacy behavior
-      for (var key in report) {
+      for (let key in report) {
         // This avoids problems with Firefox
         if (typeof report[key] === 'function') {
           continue;
@@ -2229,7 +2229,7 @@ test('getStats', {skip: true}, function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var getStatsResult = (error) ? 'error: ' + error.toString() : 'no errors';
+    let getStatsResult = (error) ? 'error: ' + error.toString() : 'no errors';
     t.ok(!error, 'GetStats result:  ' + getStatsResult);
     return driver.wait(function() {
       return driver.executeScript('return window.testsEqualArray');
@@ -2249,7 +2249,7 @@ test('getStats', {skip: true}, function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2261,20 +2261,20 @@ test('getStats', {skip: true}, function(t) {
 // as the first argument.
 // FIXME: Implement callbacks for the results as well.
 test('originalChromeGetStats', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
     window.testsEqualArray = [];
     window.testsNotEqualArray = [];
-    var pc1 = new RTCPeerConnection(null);
+    let pc1 = new RTCPeerConnection(null);
 
     new Promise(function(resolve, reject) {  // jshint ignore: line
       pc1.getStats(resolve, null);
     })
     .then(function(response) {
-      var reports = response.result();
+      let reports = response.result();
       // TODO: Figure out a way to get inheritance to work properly in
       // webdriver. report.names() is just an empty object when returned to
       // webdriver.
@@ -2307,7 +2307,7 @@ test('originalChromeGetStats', function(t) {
     .then(function(browser) {
       if (browser !== 'chrome') {
         t.skip('Non-chrome browser detected.');
-        throw 'skip-test';
+        throw new Error('skip-test');
       }
     });
   })
@@ -2315,7 +2315,7 @@ test('originalChromeGetStats', function(t) {
     return driver.executeAsyncScript(testDefinition);
   })
   .then(function(error) {
-    var getStatsResult = (error) ? 'error: ' + error.toString() : 'no errors';
+    let getStatsResult = (error) ? 'error: ' + error.toString() : 'no errors';
     t.ok(!error, 'GetStats result:  ' + getStatsResult);
     return driver.wait(function() {
       return driver.executeScript('return window.testsEqualArray');
@@ -2346,7 +2346,7 @@ test('originalChromeGetStats', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2354,20 +2354,20 @@ test('originalChromeGetStats', function(t) {
 });
 
 test('getStats promise', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Define test.
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
-    var testsEqualArray = [];
-    var pc1 = new RTCPeerConnection(null);
+    let testsEqualArray = [];
+    let pc1 = new RTCPeerConnection(null);
 
     pc1.getStats(null)
     .then(function(report) {
       testsEqualArray.push([typeof report, 'object',
         'getStats with no selector returns a Promise']);
-      // Firefox does not like getStats without any arguments, therefore we call
+      // Firefox does not like getStats without any args, therefore we call
       // the callback before the next getStats call.
       // FIXME: Remove this if ever supported by Firefox, also remove the t.skip
       // section towards the end of the // Run test section.
@@ -2378,7 +2378,7 @@ test('getStats promise', function(t) {
       pc1.getStats()
       .then(function(reportWithoutArg) {
         testsEqualArray.push([typeof reportWithoutArg, 'object',
-          'getStats with no arguments returns a Promise']);
+          'getStats with no args returns a Promise']);
         callback(testsEqualArray);
       })
       .catch(function(err) {
@@ -2419,7 +2419,7 @@ test('getStats promise', function(t) {
       'return adapter.browserDetails.browser === \'firefox\'')
       .then(function(isFirefox) {
         if (isFirefox) {
-          t.skip('Firefox does not support getStats without arguments.');
+          t.skip('Firefox does not support getStats without args.');
         }
       });
   })
@@ -2427,7 +2427,7 @@ test('getStats promise', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2440,15 +2440,15 @@ test('getStats promise', function(t) {
 test('iceTransportPolicy relay functionality',
     {skip: process.env.BROWSER !== 'chrome'},
     function(t) {
-      var driver = seleniumHelpers.buildDriver();
+      let driver = seleniumHelpers.buildDriver();
 
       // Define test.
-      var testDefinition = function() {
-        var callback = arguments[arguments.length - 1];
+      let testDefinition = function(...args) {
+        let callback = args[args.length - 1];
 
         window.candidates = [];
 
-        var pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay',
+        let pc1 = new RTCPeerConnection({iceTransportPolicy: 'relay',
           iceServers: []});
 
         // Since we try to gather only relay candidates without specifying
@@ -2462,7 +2462,7 @@ test('iceTransportPolicy relay functionality',
           }
         };
 
-        var constraints = {video: true, fake: true};
+        let constraints = {video: true, fake: true};
         navigator.mediaDevices.getUserMedia(constraints)
         .then(function(stream) {
           pc1.addStream(stream);
@@ -2485,7 +2485,7 @@ test('iceTransportPolicy relay functionality',
         return driver.executeAsyncScript(testDefinition);
       })
       .then(function(error) {
-        var errorMessage = (error) ? 'error: ' + error.toString() : 'no errors';
+        let errorMessage = (error) ? 'error: ' + error.toString() : 'no errors';
         t.ok(!error, 'Result:  ' + errorMessage);
         // We should not really need this due to using an error callback if a
         // candidate is found but I'm not sure we will catch due to async nature
@@ -2505,7 +2505,7 @@ test('iceTransportPolicy relay functionality',
         t.end();
       })
       .then(null, function(err) {
-        if (err !== 'skip-test') {
+        if (err.message !== 'skip-test') {
           t.fail(err);
         }
         t.end();
@@ -2515,20 +2515,20 @@ test('iceTransportPolicy relay functionality',
 test('icegatheringstatechange event',
     {skip: process.env.BROWSER !== 'MicrosoftEdge'},
     function(t) {
-      var driver = seleniumHelpers.buildDriver();
+      let driver = seleniumHelpers.buildDriver();
 
       // Define test.
-      var testDefinition = function() {
-        var callback = arguments[arguments.length - 1];
+      let testDefinition = function(...args) {
+        let callback = args[args.length - 1];
 
-        var pc1 = new RTCPeerConnection();
+        let pc1 = new RTCPeerConnection();
         pc1.onicegatheringstatechange = function(event) {
           if (pc1.iceGatheringState === 'complete') {
             callback();
           }
         };
 
-        var constraints = {video: true, fake: true};
+        let constraints = {video: true, fake: true};
         navigator.mediaDevices.getUserMedia(constraints)
         .then(function(stream) {
           pc1.addStream(stream);
@@ -2548,7 +2548,7 @@ test('icegatheringstatechange event',
         t.end();
       })
       .then(null, function(err) {
-        if (err !== 'skip-test') {
+        if (err.message !== 'skip-test') {
           t.fail(err);
         }
         t.end();
@@ -2556,7 +2556,7 @@ test('icegatheringstatechange event',
     });
 
 test('static generateCertificate method', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
   // Run test.
   seleniumHelpers.loadTestPage(driver)
@@ -2575,7 +2575,7 @@ test('static generateCertificate method', function(t) {
   .then(function(isSupported) {
     if (!isSupported) {
       t.skip('generateCertificate not supported on < Chrome 49');
-      throw 'skip-test';
+      throw new Error('skip-test');
     }
     return driver.executeScript(
       'return typeof RTCPeerConnection.generateCertificate === \'function\'');
@@ -2588,7 +2588,7 @@ test('static generateCertificate method', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2597,14 +2597,14 @@ test('static generateCertificate method', function(t) {
 
 // ontrack is shimmed in Chrome so we test that it is called.
 test('ontrack', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
-    var callback = arguments[arguments.length - 1];
+  let testDefinition = function(...args) {
+    let callback = args[args.length - 1];
 
     window.testPassed = [];
     window.testFailed = [];
-    var tc = {
+    let tc = {
       ok: function(ok, msg) {
         window[ok ? 'testPassed' : 'testFailed'].push(msg);
       },
@@ -2616,9 +2616,9 @@ test('ontrack', function(t) {
       },
       fail: function(msg) {
         this.ok(false, msg);
-      }
+      },
     };
-    var sdp = 'v=0\r\n' +
+    let sdp = 'v=0\r\n' +
         'o=- 166855176514521964 2 IN IP4 127.0.0.1\r\n' +
         's=-\r\n' +
         't=0 0\r\n' +
@@ -2638,7 +2638,7 @@ test('ontrack', function(t) {
         'a=msid:stream1 track1\r\n' +
         'a=ssrc:1001 cname:some\r\n';
 
-    var pc = new RTCPeerConnection(null);
+    let pc = new RTCPeerConnection(null);
 
     pc.ontrack = function(e) {
       tc.ok(true, 'pc.ontrack called');
@@ -2651,7 +2651,7 @@ test('ontrack', function(t) {
           'trackEvent.track is in stream');
 
       if (pc.getReceivers) {
-        var receivers = pc.getReceivers();
+        let receivers = pc.getReceivers();
         if (receivers && receivers.length) {
           tc.ok(receivers.indexOf(e.receiver) !== -1,
               'trackEvent.receiver matches a known receiver');
@@ -2688,10 +2688,10 @@ test('ontrack', function(t) {
   .then(function(testPassed) {
     return driver.executeScript('return window.testFailed')
     .then(function(testFailed) {
-      for (var testPass = 0; testPass < testPassed.length; testPass++) {
+      for (let testPass = 0; testPass < testPassed.length; testPass++) {
         t.pass(testPassed[testPass]);
       }
-      for (var testFail = 0; testFail < testFailed.length; testFail++) {
+      for (let testFail = 0; testFail < testFailed.length; testFail++) {
         t.fail(testFailed[testFail]);
       }
     });
@@ -2700,7 +2700,7 @@ test('ontrack', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();
@@ -2710,12 +2710,12 @@ test('ontrack', function(t) {
 // This MUST to be the last test since it loads adapter
 // again which may result in unintended behaviour.
 test('Non-module logging to console still works', function(t) {
-  var driver = seleniumHelpers.buildDriver();
+  let driver = seleniumHelpers.buildDriver();
 
-  var testDefinition = function() {
+  let testDefinition = function(...args) {
     window.testsEqualArray = [];
     window.logCount = 0;
-    var saveConsole = console.log.bind(console);
+    let saveConsole = console.log.bind(console);
     console.log = function() {
       window.logCount++;
     };
@@ -2724,7 +2724,7 @@ test('Non-module logging to console still works', function(t) {
     console.log = saveConsole;
 
     // Check for existence of variables and functions from public API.
-    window.testsEqualArray.push([typeof RTCPeerConnection,'function',
+    window.testsEqualArray.push([typeof RTCPeerConnection, 'function',
       'RTCPeerConnection is a function']);
     window.testsEqualArray.push([typeof navigator.getUserMedia, 'function',
       'getUserMedia is a function']);
@@ -2761,7 +2761,7 @@ test('Non-module logging to console still works', function(t) {
     t.end();
   })
   .then(null, function(err) {
-    if (err !== 'skip-test') {
+    if (err.message !== 'skip-test') {
       t.fail(err);
     }
     t.end();

--- a/test/unit/chrome.js
+++ b/test/unit/chrome.js
@@ -15,7 +15,7 @@ describe('Chrome shim', () => {
 
   beforeEach(() => {
     window = {
-      webkitRTCPeerConnection: function() {}
+      webkitRTCPeerConnection: function() {},
     };
   });
 

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -23,7 +23,7 @@ function mockORTC(window) {
         e.emit(ev.type, ev);
       };
       return e;
-    }
+    },
   };
   global.Event = function(type) {
     this.type = type;
@@ -39,7 +39,7 @@ function mockORTC(window) {
     this.getLocalParameters = function() {
       return {
         usernameFragment: 'someufrag',
-        password: 'somepass'
+        password: 'somepass',
       };
     };
   };
@@ -54,9 +54,9 @@ function mockORTC(window) {
         fingerprints: [
           {
             algorithm: 'alg',
-            value: 'fi:ng:ger:pr:in:t1'
-          }
-        ]
+            value: 'fi:ng:ger:pr:in:t1',
+          },
+        ],
       };
     };
   };
@@ -69,29 +69,29 @@ function mockORTC(window) {
     this.receive = function() {};
   };
   function getCapabilities(kind) {
-    var opus = {
+    let opus = {
       name: 'opus',
       kind: 'audio',
       clockRate: 48000,
       preferredPayloadType: 111,
-      numChannels: 2
+      numChannels: 2,
     };
-    var vp8 = {
+    let vp8 = {
       name: 'vp8',
       kind: 'video',
       clockRate: 90000,
       preferredPayloadType: 100,
-      numChannels: 1
+      numChannels: 1,
     };
-    var rtx = {
+    let rtx = {
       name: 'rtx',
       kind: 'video',
       clockRate: 90000,
       preferredPayloadType: 101,
       numChannels: 1,
-      parameters: {apt: 100}
+      parameters: {apt: 100},
     };
-    var codecs;
+    let codecs;
     switch (kind) {
       case 'audio':
         codecs = [opus];
@@ -105,7 +105,7 @@ function mockORTC(window) {
     }
     return {
       codecs: codecs,
-      headerExtensions: []
+      headerExtensions: [],
     };
   }
   window.RTCRtpReceiver.getCapabilities = getCapabilities;
@@ -121,8 +121,8 @@ function mockORTC(window) {
     this.id = SDPUtils.generateIdentifier();
     this._tracks = tracks || [];
     this.getTracks = () => this._tracks;
-    this.getAudioTracks = () => this._tracks.filter(t => t.kind === 'audio');
-    this.getVideoTracks = () => this._tracks.filter(t => t.kind === 'video');
+    this.getAudioTracks = () => this._tracks.filter((t) => t.kind === 'audio');
+    this.getVideoTracks = () => this._tracks.filter((t) => t.kind === 'video');
     this.addTrack = (t) => this._tracks.push(t);
   };
   window.MediaStreamTrack = function() {
@@ -146,8 +146,8 @@ describe('Edge shim', () => {
     window = {
       navigator: {
         userAgent: ua15025,
-        mediaDevices: function() {}
-      }
+        mediaDevices: function() {},
+      },
     };
     mockORTC(window);
     shim.shimPeerConnection(window);
@@ -172,17 +172,17 @@ describe('Edge shim', () => {
       // need to re-evaluate after changing the browser version.
       shim.shimPeerConnection(window);
       pc = new window.RTCPeerConnection({
-        iceServers: [{urls: 'stun:stun.l.google.com'}]
+        iceServers: [{urls: 'stun:stun.l.google.com'}],
       });
       expect(pc.iceOptions.iceServers).to.deep.equal([]);
     });
 
     it('does not filter STUN after r14393', () => {
       pc = new window.RTCPeerConnection({
-        iceServers: [{urls: 'stun:stun.l.google.com'}]
+        iceServers: [{urls: 'stun:stun.l.google.com'}],
       });
       expect(pc.iceOptions.iceServers).to.deep.equal([
-        {urls: 'stun:stun.l.google.com'}
+        {urls: 'stun:stun.l.google.com'},
       ]);
     });
 
@@ -190,8 +190,8 @@ describe('Edge shim', () => {
       pc = new window.RTCPeerConnection({
         iceServers: [
           {urls: 'turn:stun.l.google.com'},
-          {urls: 'turn:stun.l.google.com:19302'}
-        ]
+          {urls: 'turn:stun.l.google.com:19302'},
+        ],
       });
       expect(pc.iceOptions.iceServers).to.deep.equal([]);
     });
@@ -199,8 +199,8 @@ describe('Edge shim', () => {
     it('filters TURN TCP', () => {
       pc = new window.RTCPeerConnection({
         iceServers: [
-          {urls: 'turn:stun.l.google.com:19302?transport=tcp'}
-        ]
+          {urls: 'turn:stun.l.google.com:19302?transport=tcp'},
+        ],
       });
       expect(pc.iceOptions.iceServers).to.deep.equal([]);
     });
@@ -211,12 +211,12 @@ describe('Edge shim', () => {
           iceServers: [
             {urls: 'stun:stun.l.google.com'},
             {urls: 'turn:stun.l.google.com:19301?transport=udp'},
-            {urls: 'turn:stun.l.google.com:19302?transport=udp'}
-          ]
+            {urls: 'turn:stun.l.google.com:19302?transport=udp'},
+          ],
         });
         expect(pc.iceOptions.iceServers).to.deep.equal([
           {urls: 'stun:stun.l.google.com'},
-          {urls: 'turn:stun.l.google.com:19301?transport=udp'}
+          {urls: 'turn:stun.l.google.com:19301?transport=udp'},
         ]);
       });
 
@@ -226,13 +226,13 @@ describe('Edge shim', () => {
             {urls: 'stun:stun.l.google.com'},
             {urls: [
               'turn:stun.l.google.com:19301?transport=udp',
-              'turn:stun.l.google.com:19302?transport=udp'
-            ]}
-          ]
+              'turn:stun.l.google.com:19302?transport=udp',
+            ]},
+          ],
         });
         expect(pc.iceOptions.iceServers).to.deep.equal([
           {urls: 'stun:stun.l.google.com'},
-          {urls: ['turn:stun.l.google.com:19301?transport=udp']}
+          {urls: ['turn:stun.l.google.com:19301?transport=udp']},
         ]);
       });
     });

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -105,7 +105,7 @@ describe('extractVersion', () => {
 
   describe('Edge regular expression', () => {
     const expr = /Edge\/(\d+).(\d+)$/;
-    it ('matches the Edge build number', () => {
+    it('matches the Edge build number', () => {
       ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
           '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
       expect(extractVersion(ua, expr, 2)).to.equal(10547);

--- a/test/unit/firefox.js
+++ b/test/unit/firefox.js
@@ -17,7 +17,7 @@ describe('Firefox shim', () => {
     window = {
       mozRTCPeerConnection: function() {},
       mozRTCSessionDescription: function() {},
-      mozRTCIceCandidate: function() {}
+      mozRTCIceCandidate: function() {},
     };
   });
 

--- a/test/unit/getusermedia-constraints.js
+++ b/test/unit/getusermedia-constraints.js
@@ -22,8 +22,8 @@ describe('Chrome getUserMedia constraints converter', () => {
         webkitGetUserMedia: sinon.stub(),
         userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
             'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.3029.110 ' +
-            'Safari/537.36'
-      }
+            'Safari/537.36',
+      },
     };
     shim(window);
   });
@@ -33,8 +33,8 @@ describe('Chrome getUserMedia constraints converter', () => {
       video: {
         width: 1280,
         height: {min: 200, ideal: 720, max: 1080},
-        frameRate: {exact: 50}
-      }
+        frameRate: {exact: 50},
+      },
     });
     expect(window.navigator.webkitGetUserMedia).to.have.been.calledWith({
       video: {
@@ -42,15 +42,15 @@ describe('Chrome getUserMedia constraints converter', () => {
           maxFrameRate: 50,
           maxHeight: 1080,
           minHeight: 200,
-          minFrameRate: 50
+          minFrameRate: 50,
         },
         optional: [
                 {minWidth: 1280},
                 {maxWidth: 1280},
                 {minHeight: 720},
-                {maxHeight: 720}
-        ]
-      }
+                {maxHeight: 720},
+        ],
+      },
     });
   });
 
@@ -61,15 +61,15 @@ describe('Chrome getUserMedia constraints converter', () => {
           maxFrameRate: 50,
           maxHeight: 1080,
           minHeight: 200,
-          minFrameRate: 50
+          minFrameRate: 50,
         },
         optional: [
                 {minWidth: 1280},
                 {maxWidth: 1280},
                 {minHeight: 720},
-                {maxHeight: 720}
-        ]
-      }
+                {maxHeight: 720},
+        ],
+      },
     };
     window.navigator.getUserMedia(legacy);
     expect(window.navigator.webkitGetUserMedia).to.have.been.calledWith(legacy);
@@ -80,17 +80,17 @@ describe('Chrome getUserMedia constraints converter', () => {
       video: {
         mediaSource: 'screen',
         advanced: [
-                {facingMode: 'user'}
+                {facingMode: 'user'},
         ],
-        require: ['height', 'frameRate']
-      }
+        require: ['height', 'frameRate'],
+      },
     });
     expect(window.navigator.webkitGetUserMedia).to.have.been.calledWith({
       video: {
         optional: [
-                {facingMode: 'user'}
-        ]
-      }
+                {facingMode: 'user'},
+        ],
+      },
     });
   });
 });
@@ -102,8 +102,8 @@ describe('Firefox getUserMedia constraints converter', () => {
   beforeEach(() => {
     window = {
       navigator: {
-        mozGetUserMedia: sinon.stub()
-      }
+        mozGetUserMedia: sinon.stub(),
+      },
     };
   });
 
@@ -121,8 +121,8 @@ describe('Firefox getUserMedia constraints converter', () => {
           width: 1280,
           height: {min: 200, ideal: 720, max: 1080},
           facingMode: 'user',
-          frameRate: {exact: 50}
-        }
+          frameRate: {exact: 50},
+        },
       });
       expect(window.navigator.mozGetUserMedia).to.have.been.calledWith({
         video: {
@@ -132,10 +132,10 @@ describe('Firefox getUserMedia constraints converter', () => {
           advanced: [
                   {width: {min: 1280, max: 1280}},
                   {height: {min: 720, max: 720}},
-                  {facingMode: 'user'}
+                  {facingMode: 'user'},
           ],
-          require: ['height', 'frameRate']
-        }
+          require: ['height', 'frameRate'],
+        },
       });
     });
 
@@ -147,10 +147,10 @@ describe('Firefox getUserMedia constraints converter', () => {
           advanced: [
                   {width: {min: 1280, max: 1280}},
                   {height: {min: 720, max: 720}},
-                  {facingMode: 'user'}
+                  {facingMode: 'user'},
           ],
-          require: ['height', 'frameRate']
-        }
+          require: ['height', 'frameRate'],
+        },
       };
       window.navigator.getUserMedia(legacy);
       expect(window.navigator.mozGetUserMedia).to.have.been.calledWith(legacy);
@@ -169,8 +169,8 @@ describe('Firefox getUserMedia constraints converter', () => {
         width: 1280,
         height: {min: 200, ideal: 720, max: 1080},
         facingMode: 'user',
-        frameRate: {exact: 50}
-      }
+        frameRate: {exact: 50},
+      },
       };
       window.navigator.getUserMedia(spec);
       expect(window.navigator.mozGetUserMedia).to.have.been.calledWith(spec);

--- a/test/unit/logSuppression.js
+++ b/test/unit/logSuppression.js
@@ -16,7 +16,7 @@ describe('Log suppression', () => {
   let logCount;
   beforeEach(() => {
     logCount = 0;
-    console.log = function() {
+    console.log = function(arguments) {
       if (arguments.length === 1 && arguments[0] === 'test') {
         logCount++;
       } else {

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -18,7 +18,7 @@ describe('Safari shim', () => {
 
   beforeEach(() => {
     window = {
-      RTCPeerConnection: function() {}
+      RTCPeerConnection: function() {},
     };
   });
 


### PR DESCRIPTION
**Description**
Use eslint-config-google but disable jsdoc and es6 rules. Tests are exempted and es6 rules are explicit enabled since we use es6 there.

**Purpose**
Adhere to the google style guide.

Note: This is not rebased with the latest changes yet, will do once it's ready before submitting this.