### PR TITLE
edge: fix issue with disposing a non-existing transceiver

### DIFF
--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -767,7 +767,8 @@ module.exports = function(window, edgeVersion) {
 
       // Check if we can use BUNDLE and dispose transports.
       if ((description.type === 'offer' || description.type === 'answer') &&
-          !rejected && usingBundle && sdpMLineIndex > 0) {
+          !rejected && usingBundle && sdpMLineIndex > 0 &&
+          self.transceivers[sdpMLineIndex]) {
         self._disposeIceAndDtlsTransports(sdpMLineIndex);
         self.transceivers[sdpMLineIndex].iceGatherer =
             self.transceivers[0].iceGatherer;


### PR DESCRIPTION
fixes an issue where, when SRD was called, an attempt was made
to dispose the icetransport of a transceiver which was not created.

introduced in #561, uncovered by a unit test with two m-lines and bundle (of which there are too few obviously)