### PR TITLE
build: allow publishing patch versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Head over to [test/README.md](https://github.com/webrtc/samples/blob/gh-pages/te
 
 ## Publish a new version ##
 * Go the the adapter repository root directory
-* Make sure your repository is clean, i.e. no untracked files etc
+* Make sure your repository is clean, i.e. no untracked files etc. Also check that you are on the master branch and have pulled the latest changes.
 * Depending on the impact of the release, either use `patch`, `minor` or `major` in place of `<version>`. Run `npm version <version> -m 'bump to %s'` and type in your password lots of times (setting up credential caching is probably a good idea).
 * Create and merge the PR if green in the GitHub web ui
 * Go to the releases tab in the GitHub web ui and edit the tag.
@@ -55,3 +55,13 @@ Head over to [test/README.md](https://github.com/webrtc/samples/blob/gh-pages/te
 * Done! There should now be a new release published to NPM and the gh-pages branch.
 
 Note: Currently only tested on Linux, not sure about Mac but will definitely not work on Windows.
+
+### Publish a hotfix patch versions
+In some cases it may be necessary to do a patch version while there are significant changes changes on the master branch.
+To make a patch release,
+* checkout the latest git tag using `git checkout tags/vMajor.minor.patch`.
+* checkout a new branch, using a name such as patchrelease-major-minor-patch. 
+* cherry-pick the fixes using `git cherry-pick some-commit-hash`.
+* run `npm version patch`. This will create a new patch version and publish it on github.
+* check out the branch created earlier and publish the new version using `npm publish`.
+* the branch can now safely be deleted. It is not necessary to merge it into the main branch since it only contains cherry-picked commits.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "The WebRTC project authors (https://www.webrtc.org/)"
   ],
   "scripts": {
-    "preversion": "git stash && git checkout master && git pull && npm install && npm test | faucet && git checkout -B bumpVersion && grunt build && grunt copyForPublish && git add package.json release/* && git commit -m 'Add adapter artifacts' --allow-empty",
+    "preversion": "git stash && npm install && npm test | faucet && git checkout -B bumpVersion && grunt build && grunt copyForPublish && git add package.json release/* && git commit -m 'Add adapter artifacts' --allow-empty",
     "version": "",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir -p adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",


### PR DESCRIPTION
allows creating patch versions from a past git tag and adds a description how to do that.

@KaptenJansson wdyt? I think that is better than what I came up with earlier.
It also struck me that we do the copy to github on npm version and not npm publish.