### PR TITLE
chrome: change addTrack call order

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -113,8 +113,8 @@ var chromeShim = {
           pc._streams = pc._streams || {};
           var oldStream = pc._streams[stream.id];
           if (oldStream) {
-            oldStream.addTrack(track);
             pc.removeStream(oldStream);
+            oldStream.addTrack(track);
             pc.addStream(oldStream);
           } else {
             var newStream = new MediaStream([track]);


### PR DESCRIPTION
moves removeTrack a bit earlier so that removeTrack is
called with the same track that was added. Without this, the following happens:
```
pc.addStream(stream with just audio track)
pc.removeStream(stream with audio and video track)
pc.addStream(stream with audio and video track)
```
which makes me a bit uneasy.

Still pondering if I should intercept ONN to avoid https://bugs.chromium.org/p/webrtc/issues/detail?id=7693 ...