### PR TITLE
Transition adapter.js to ES modules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,6 +50,9 @@
       "browser": true,
       "node": true
   },
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "extends": ["eslint:recommended", "webrtc"],
   "globals": {
     "module": true,

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ firefox-*.tar.bz2
 .DS_Store
 node_modules/
 out/
+.reify-cache/
 validation-report.json
 validation-status.json
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,51 +1,55 @@
 'use strict';
+var commonjs = require('rollup-plugin-commonjs');
+var ignore = require('rollup-plugin-ignore');
+var nodeResolve = require('rollup-plugin-node-resolve');
+
+var ignoreEdge = [ignore('./edge/edge_shim.js')];
 
 module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
-    browserify: {
+    rollup: {
+      options: {
+        format: 'umd',
+        moduleName: 'adapter',
+        indent: false,
+        plugins: [
+          nodeResolve(),
+          commonjs({ include: 'node_modules/sdp/**/*.js' })
+        ]
+      },
       adapterGlobalObject: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter.js',
-        options: {
-          browserifyOptions: {
-            // Exposes shim methods in a global object to the browser.
-            // The tests require this.
-            standalone: 'adapter'
-          }
-        }
+        src: './src/js/adapter_core.js',
+        dest: './out/adapter.js'
       },
       // Use this if you do not want adapter to expose anything to the global
       // scope.
       adapterAndNoGlobalObject: {
-        src: ['./src/js/adapter_core.js'],
+        options: {
+          format: 'iife',
+          exports: 'none',
+        },
+        src: './src/js/adapter_private.js',
         dest: './out/adapter_no_global.js'
       },
       // Use this if you do not want Microsoft Edge shim to be included.
       adapterNoEdge: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_no_edge.js',
         options: {
-          // These files will be skipped.
-          ignore: [
-            './src/js/edge/edge_shim.js'
-          ],
-          browserifyOptions: {
-            // Exposes the shim in a global object to the browser.
-            standalone: 'adapter'
-          }
-        }
+          plugins: ignoreEdge
+        },
+        src: './src/js/adapter_core.js',
+        dest: './out/adapter_no_edge.js'
       },
       // Use this if you do not want Microsoft Edge shim to be included and
       // do not want adapter to expose anything to the global scope.
       adapterNoEdgeAndNoGlobalObject: {
-        src: ['./src/js/adapter_core.js'],
-        dest: './out/adapter_no_edge_no_global.js',
         options: {
-          ignore: [
-            './src/js/edge/edge_shim.js'
-          ]
-        }
+          format: 'iife',
+          exports: 'none',
+          plugins: ignoreEdge
+        },
+        src: './src/js/adapter_private.js',
+        dest: './out/adapter_no_edge_no_global.js'
       }
     },
     githooks: {
@@ -72,11 +76,11 @@ module.exports = function(grunt) {
 
   grunt.loadNpmTasks('grunt-githooks');
   grunt.loadNpmTasks('grunt-eslint');
-  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-rollup');
   grunt.loadNpmTasks('grunt-contrib-copy');
 
-  grunt.registerTask('default', ['eslint', 'browserify']);
+  grunt.registerTask('default', ['eslint', 'rollup']);
   grunt.registerTask('lint', ['eslint']);
-  grunt.registerTask('build', ['browserify']);
+  grunt.registerTask('build', ['rollup']);
   grunt.registerTask('copyForPublish', ['copy']);
 };

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "4.0.2",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
-  "main": "./src/js/adapter_core.js",
+  "main": "./out/adapter.js",
+  "module": "./src/js/adapter_core.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/webrtc/adapter.git"
@@ -16,7 +17,7 @@
     "version": "",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/adapter.js adapter.js && cp adapter.js adapter-`$GITTAG`.js && rm adapter-latest.js && ln -s adapter-`$GITTAG`.js adapter-latest.js && mkdir -p adapter-`$GITTAG`-variants && cp out/adapter.js adapter-`$GITTAG`-variants/ && cp out/adapter_*.js adapter-`$GITTAG`-variants/ && git add adapter.js adapter-latest.js adapter-`$GITTAG`.js adapter-`$GITTAG`-variants && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
-    "test": "grunt && mocha test/unit && karma start test/karma.conf.js && node test/run-tests.js"
+    "test": "grunt && mocha --require reify/node test/unit && karma start test/karma.conf.js && node test/run-tests.js"
   },
   "dependencies": {
     "sdp": "^2.1.0"
@@ -33,14 +34,13 @@
     "faucet": "0.0.1",
     "geckodriver": "1.4.0",
     "grunt": "^0.4.5",
-    "grunt-browserify": "^4.0.1",
     "grunt-cli": ">=0.1.9",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-eslint": "^19.0.0",
     "grunt-githooks": "^0.3.1",
+    "grunt-rollup": "^1.0.1",
     "karma": "^1.7.0",
-    "karma-browserify": "^5.1.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.2.0",
     "karma-edge-launcher": "^0.4.1",
@@ -49,6 +49,10 @@
     "karma-mocha-reporter": "^2.2.3",
     "karma-safari-launcher": "^1.0.0",
     "mocha": "^3.2.0",
+    "reify": "^0.11.0",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-ignore": "^1.0.3",
+    "rollup-plugin-node-resolve": "^3.0.0",
     "selenium-webdriver": "3.3.0",
     "sinon": "^2.2.0",
     "sinon-chai": "^2.10.0",

--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -5,9 +5,6 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
+import adapterFactory from './adapter_factory.js';
 
-'use strict';
-
-var adapterFactory = require('./adapter_factory.js');
-module.exports = adapterFactory({window: global.window});
+export default adapterFactory({window: window});

--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -5,12 +5,14 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-
-'use strict';
+import chromeShim from './chrome/chrome_shim.js';
+import edgeShim from './edge/edge_shim.js';
+import firefoxShim from './firefox/firefox_shim.js';
+import safariShim from './safari/safari_shim.js';
+import * as utils from './utils.js';
 
 // Shimming starts here.
-module.exports = function(dependencies, opts) {
+export default function(dependencies, opts) {
   var window = dependencies && dependencies.window;
 
   var options = Object.assign({
@@ -21,8 +23,6 @@ module.exports = function(dependencies, opts) {
   }, opts);
 
   // Utils.
-  var utils = require('./utils');
-  var logging = utils.log;
   var browserDetails = utils.detectBrowser(window);
 
   // Export to the adapter global object visible in the browser.
@@ -37,23 +37,17 @@ module.exports = function(dependencies, opts) {
   // for the switch statement below. Can also be turned on in the browser via
   // adapter.disableLog(false), but then logging from the switch statement below
   // will not appear.
-  // require('./utils').disableLog(false);
-
-  // Browser shims.
-  var chromeShim = require('./chrome/chrome_shim') || null;
-  var edgeShim = require('./edge/edge_shim') || null;
-  var firefoxShim = require('./firefox/firefox_shim') || null;
-  var safariShim = require('./safari/safari_shim') || null;
+  // utils.disableLog(false);
 
   // Shim browser if found.
   switch (browserDetails.browser) {
     case 'chrome':
       if (!chromeShim || !chromeShim.shimPeerConnection ||
           !options.shimChrome) {
-        logging('Chrome shim is not included in this adapter release.');
+        utils.log('Chrome shim is not included in this adapter release.');
         return adapter;
       }
-      logging('adapter.js shimming chrome.');
+      utils.log('adapter.js shimming chrome.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = chromeShim;
 
@@ -69,10 +63,10 @@ module.exports = function(dependencies, opts) {
     case 'firefox':
       if (!firefoxShim || !firefoxShim.shimPeerConnection ||
           !options.shimFirefox) {
-        logging('Firefox shim is not included in this adapter release.');
+        utils.log('Firefox shim is not included in this adapter release.');
         return adapter;
       }
-      logging('adapter.js shimming firefox.');
+      utils.log('adapter.js shimming firefox.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = firefoxShim;
 
@@ -84,10 +78,10 @@ module.exports = function(dependencies, opts) {
       break;
     case 'edge':
       if (!edgeShim || !edgeShim.shimPeerConnection || !options.shimEdge) {
-        logging('MS edge shim is not included in this adapter release.');
+        utils.log('MS edge shim is not included in this adapter release.');
         return adapter;
       }
-      logging('adapter.js shimming edge.');
+      utils.log('adapter.js shimming edge.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = edgeShim;
 
@@ -98,10 +92,10 @@ module.exports = function(dependencies, opts) {
       break;
     case 'safari':
       if (!safariShim || !options.shimSafari) {
-        logging('Safari shim is not included in this adapter release.');
+        utils.log('Safari shim is not included in this adapter release.');
         return adapter;
       }
-      logging('adapter.js shimming safari.');
+      utils.log('adapter.js shimming safari.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = safariShim;
       // shim window.URL.createObjectURL Safari (technical preview)
@@ -113,9 +107,9 @@ module.exports = function(dependencies, opts) {
       safariShim.shimGetUserMedia(window);
       break;
     default:
-      logging('Unsupported browser!');
+      utils.log('Unsupported browser!');
       break;
   }
 
   return adapter;
-};
+}

--- a/src/js/adapter_private.js
+++ b/src/js/adapter_private.js
@@ -1,0 +1,10 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+// Import adapter, but don't export it.
+import './adapter_core.js';

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -6,12 +6,13 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
-var utils = require('../utils.js');
+import shimGetUserMedia from './getusermedia.js';
+import * as utils from '../utils.js';
 var logging = utils.log;
 
-var chromeShim = {
+export default {
+  shimGetUserMedia: shimGetUserMedia,
+
   shimMediaStream: function(window) {
     window.MediaStream = window.MediaStream || window.webkitMediaStream;
   },
@@ -490,17 +491,5 @@ var chromeShim = {
       }
       return nativeAddIceCandidate.apply(this, arguments);
     };
-  }
-};
-
-
-// Expose public methods.
-module.exports = {
-  shimMediaStream: chromeShim.shimMediaStream,
-  shimOnTrack: chromeShim.shimOnTrack,
-  shimAddTrack: chromeShim.shimAddTrack,
-  shimGetSendersWithDtmf: chromeShim.shimGetSendersWithDtmf,
-  shimSourceObject: chromeShim.shimSourceObject,
-  shimPeerConnection: chromeShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia')
+  },
 };

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -5,13 +5,11 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
-var utils = require('../utils.js');
+import * as utils from '../utils';
 var logging = utils.log;
 
 // Expose public methods.
-module.exports = function(window) {
+export default function(window) {
   var browserDetails = utils.detectBrowser(window);
   var navigator = window && window.navigator;
 
@@ -232,4 +230,4 @@ module.exports = function(window) {
       logging('Dummy mediaDevices.removeEventListener called.');
     };
   }
-};
+}

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -5,14 +5,12 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
+import * as utils from '../utils.js';
+import shimGetUserMedia from './getusermedia.js';
+import shimRTCPeerConnection from './rtcpeerconnection_shim.js';
 
-var utils = require('../utils');
-var shimRTCPeerConnection = require('./rtcpeerconnection_shim');
-
-module.exports = {
-  shimGetUserMedia: require('./getusermedia'),
+export default {
+  shimGetUserMedia: shimGetUserMedia,
   shimPeerConnection: function(window) {
     var browserDetails = utils.detectBrowser(window);
 

--- a/src/js/edge/getusermedia.js
+++ b/src/js/edge/getusermedia.js
@@ -5,11 +5,9 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
 
 // Expose public methods.
-module.exports = function(window) {
+export default function(window) {
   var navigator = window && window.navigator;
 
   var shimError_ = function(e) {
@@ -31,4 +29,4 @@ module.exports = function(window) {
       return Promise.reject(shimError_(e));
     });
   };
-};
+}

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -5,10 +5,7 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
-
-var SDPUtils = require('sdp');
+import SDPUtils from 'sdp';
 
 // sort tracks such that they follow an a-v-a-v...
 // pattern.
@@ -162,7 +159,7 @@ function isActionAllowedInSignalingState(action, type, signalingState) {
   }[type][action].indexOf(signalingState) !== -1;
 }
 
-module.exports = function(window, edgeVersion) {
+export default function(window, edgeVersion) {
   var RTCPeerConnection = function(config) {
     var self = this;
 
@@ -1386,4 +1383,4 @@ module.exports = function(window, edgeVersion) {
     });
   };
   return RTCPeerConnection;
-};
+}

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -5,12 +5,10 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
+import shimGetUserMedia from './getusermedia.js';
+import * as utils from '../utils';
 
-var utils = require('../utils');
-
-var firefoxShim = {
+export default {
   shimOnTrack: function(window) {
     if (typeof window === 'object' && window.RTCPeerConnection && !('ontrack' in
         window.RTCPeerConnection.prototype)) {
@@ -186,13 +184,7 @@ var firefoxShim = {
         })
         .then(onSucc, onErr);
     };
-  }
-};
+  },
 
-// Expose public methods.
-module.exports = {
-  shimOnTrack: firefoxShim.shimOnTrack,
-  shimSourceObject: firefoxShim.shimSourceObject,
-  shimPeerConnection: firefoxShim.shimPeerConnection,
-  shimGetUserMedia: require('./getusermedia')
+  shimGetUserMedia: shimGetUserMedia
 };

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -5,14 +5,11 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
-
-var utils = require('../utils');
+import * as utils from '../utils';
 var logging = utils.log;
 
 // Expose public methods.
-module.exports = function(window) {
+export default function(window) {
   var browserDetails = utils.detectBrowser(window);
   var navigator = window && window.navigator;
   var MediaStreamTrack = window && window.MediaStreamTrack;
@@ -206,4 +203,4 @@ module.exports = function(window) {
                  'navigator.mediaDevices.getUserMedia');
     navigator.mediaDevices.getUserMedia(constraints).then(onSuccess, onError);
   };
-};
+}

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -5,10 +5,9 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
-'use strict';
-var utils = require('../utils');
+import * as utils from '../utils.js';
 
-var safariShim = {
+export default {
   // TODO: DrAlex, should be here, double check against LayoutTests
 
   // TODO: once the back-end for the mac port is done, add.
@@ -237,15 +236,4 @@ var safariShim = {
       }
     });
   }
-};
-
-// Expose public methods.
-module.exports = {
-  shimCallbacksAPI: safariShim.shimCallbacksAPI,
-  shimLocalStreamsAPI: safariShim.shimLocalStreamsAPI,
-  shimRemoteStreamsAPI: safariShim.shimRemoteStreamsAPI,
-  shimGetUserMedia: safariShim.shimGetUserMedia,
-  shimRTCIceServerUrls: safariShim.shimRTCIceServerUrls
-  // TODO
-  // shimPeerConnection: safariShim.shimPeerConnection
 };

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -5,193 +5,178 @@
  *  that can be found in the LICENSE file in the root of the source
  *  tree.
  */
- /* eslint-env node */
-'use strict';
 
 var logDisabled_ = true;
 var deprecationWarnings_ = true;
 
 // Utility methods.
-var utils = {
-  disableLog: function(bool) {
-    if (typeof bool !== 'boolean') {
-      return new Error('Argument type: ' + typeof bool +
-          '. Please use a boolean.');
-    }
-    logDisabled_ = bool;
-    return (bool) ? 'adapter.js logging disabled' :
-        'adapter.js logging enabled';
-  },
+export function disableLog(bool) {
+  if (typeof bool !== 'boolean') {
+    return new Error('Argument type: ' + typeof bool +
+        '. Please use a boolean.');
+  }
+  logDisabled_ = bool;
+  return (bool) ? 'adapter.js logging disabled' :
+      'adapter.js logging enabled';
+}
 
-  /**
-   * Disable or enable deprecation warnings
-   * @param {!boolean} bool set to true to disable warnings.
-   */
-  disableWarnings: function(bool) {
-    if (typeof bool !== 'boolean') {
-      return new Error('Argument type: ' + typeof bool +
-          '. Please use a boolean.');
-    }
-    deprecationWarnings_ = !bool;
-    return 'adapter.js deprecation warnings ' + (bool ? 'disabled' : 'enabled');
-  },
+/**
+ * Disable or enable deprecation warnings
+ * @param {!boolean} bool set to true to disable warnings.
+ */
+export function disableWarnings(bool) {
+  if (typeof bool !== 'boolean') {
+    return new Error('Argument type: ' + typeof bool +
+        '. Please use a boolean.');
+  }
+  deprecationWarnings_ = !bool;
+  return 'adapter.js deprecation warnings ' + (bool ? 'disabled' : 'enabled');
+}
 
-  log: function() {
-    if (typeof window === 'object') {
-      if (logDisabled_) {
-        return;
-      }
-      if (typeof console !== 'undefined' && typeof console.log === 'function') {
-        console.log.apply(console, arguments);
-      }
-    }
-  },
-
-  /**
-   * Shows a deprecation warning suggesting the modern and spec-compatible API.
-   */
-  deprecated: function(oldMethod, newMethod) {
-    if (!deprecationWarnings_) {
+export function log() {
+  if (typeof window === 'object') {
+    if (logDisabled_) {
       return;
     }
-    console.warn(oldMethod + ' is deprecated, please use ' + newMethod +
-        ' instead.');
-  },
-
-  /**
-   * Extract browser version out of the provided user agent string.
-   *
-   * @param {!string} uastring userAgent string.
-   * @param {!string} expr Regular expression used as match criteria.
-   * @param {!number} pos position in the version string to be returned.
-   * @return {!number} browser version.
-   */
-  extractVersion: function(uastring, expr, pos) {
-    var match = uastring.match(expr);
-    return match && match.length >= pos && parseInt(match[pos], 10);
-  },
-
-  /**
-   * Browser detector.
-   *
-   * @return {object} result containing browser and version
-   *     properties.
-   */
-  detectBrowser: function(window) {
-    var navigator = window && window.navigator;
-
-    // Returned result object.
-    var result = {};
-    result.browser = null;
-    result.version = null;
-
-    // Fail early if it's not a browser
-    if (typeof window === 'undefined' || !window.navigator) {
-      result.browser = 'Not a browser.';
-      return result;
+    if (typeof console !== 'undefined' && typeof console.log === 'function') {
+      console.log.apply(console, arguments);
     }
-
-    // Firefox.
-    if (navigator.mozGetUserMedia) {
-      result.browser = 'firefox';
-      result.version = this.extractVersion(navigator.userAgent,
-          /Firefox\/(\d+)\./, 1);
-    } else if (navigator.webkitGetUserMedia) {
-      // Chrome, Chromium, Webview, Opera, all use the chrome shim for now
-      if (window.webkitRTCPeerConnection) {
-        result.browser = 'chrome';
-        result.version = this.extractVersion(navigator.userAgent,
-          /Chrom(e|ium)\/(\d+)\./, 2);
-      } else { // Safari (in an unpublished version) or unknown webkit-based.
-        if (navigator.userAgent.match(/Version\/(\d+).(\d+)/)) {
-          result.browser = 'safari';
-          result.version = this.extractVersion(navigator.userAgent,
-            /AppleWebKit\/(\d+)\./, 1);
-        } else { // unknown webkit-based browser.
-          result.browser = 'Unsupported webkit-based browser ' +
-              'with GUM support but no WebRTC support.';
-          return result;
-        }
-      }
-    } else if (navigator.mediaDevices &&
-        navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) { // Edge.
-      result.browser = 'edge';
-      result.version = this.extractVersion(navigator.userAgent,
-          /Edge\/(\d+).(\d+)$/, 2);
-    } else if (navigator.mediaDevices &&
-        navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
-        // Safari, with webkitGetUserMedia removed.
-      result.browser = 'safari';
-      result.version = this.extractVersion(navigator.userAgent,
-          /AppleWebKit\/(\d+)\./, 1);
-    } else { // Default fallthrough: not supported.
-      result.browser = 'Not a supported browser.';
-      return result;
-    }
-
-    return result;
-  },
-
-  // shimCreateObjectURL must be called before shimSourceObject to avoid loop.
-
-  shimCreateObjectURL: function(window) {
-    var URL = window && window.URL;
-
-    if (!(typeof window === 'object' && window.HTMLMediaElement &&
-          'srcObject' in window.HTMLMediaElement.prototype)) {
-      // Only shim CreateObjectURL using srcObject if srcObject exists.
-      return undefined;
-    }
-
-    var nativeCreateObjectURL = URL.createObjectURL.bind(URL);
-    var nativeRevokeObjectURL = URL.revokeObjectURL.bind(URL);
-    var streams = new Map(), newId = 0;
-
-    URL.createObjectURL = function(stream) {
-      if ('getTracks' in stream) {
-        var url = 'polyblob:' + (++newId);
-        streams.set(url, stream);
-        utils.deprecated('URL.createObjectURL(stream)',
-            'elem.srcObject = stream');
-        return url;
-      }
-      return nativeCreateObjectURL(stream);
-    };
-    URL.revokeObjectURL = function(url) {
-      nativeRevokeObjectURL(url);
-      streams.delete(url);
-    };
-
-    var dsc = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype,
-                                              'src');
-    Object.defineProperty(window.HTMLMediaElement.prototype, 'src', {
-      get: function() {
-        return dsc.get.apply(this);
-      },
-      set: function(url) {
-        this.srcObject = streams.get(url) || null;
-        return dsc.set.apply(this, [url]);
-      }
-    });
-
-    var nativeSetAttribute = window.HTMLMediaElement.prototype.setAttribute;
-    window.HTMLMediaElement.prototype.setAttribute = function() {
-      if (arguments.length === 2 &&
-          ('' + arguments[0]).toLowerCase() === 'src') {
-        this.srcObject = streams.get(arguments[1]) || null;
-      }
-      return nativeSetAttribute.apply(this, arguments);
-    };
   }
-};
+}
 
-// Export.
-module.exports = {
-  log: utils.log,
-  deprecated: utils.deprecated,
-  disableLog: utils.disableLog,
-  disableWarnings: utils.disableWarnings,
-  extractVersion: utils.extractVersion,
-  shimCreateObjectURL: utils.shimCreateObjectURL,
-  detectBrowser: utils.detectBrowser.bind(utils)
-};
+/**
+ * Shows a deprecation warning suggesting the modern and spec-compatible API.
+ */
+export function deprecated(oldMethod, newMethod) {
+  if (!deprecationWarnings_) {
+    return;
+  }
+  console.warn(oldMethod + ' is deprecated, please use ' + newMethod +
+      ' instead.');
+}
+
+/**
+ * Extract browser version out of the provided user agent string.
+ *
+ * @param {!string} uastring userAgent string.
+ * @param {!string} expr Regular expression used as match criteria.
+ * @param {!number} pos position in the version string to be returned.
+ * @return {!number} browser version.
+ */
+export function extractVersion(uastring, expr, pos) {
+  var match = uastring.match(expr);
+  return match && match.length >= pos && parseInt(match[pos], 10);
+}
+
+/**
+ * Browser detector.
+ *
+ * @return {object} result containing browser and version
+ *     properties.
+ */
+export function detectBrowser(window) {
+  var navigator = window && window.navigator;
+
+  // Returned result object.
+  var result = {};
+  result.browser = null;
+  result.version = null;
+
+  // Fail early if it's not a browser
+  if (typeof window === 'undefined' || !window.navigator) {
+    result.browser = 'Not a browser.';
+    return result;
+  }
+
+  // Firefox.
+  if (navigator.mozGetUserMedia) {
+    result.browser = 'firefox';
+    result.version = extractVersion(navigator.userAgent,
+        /Firefox\/(\d+)\./, 1);
+  } else if (navigator.webkitGetUserMedia) {
+    // Chrome, Chromium, Webview, Opera, all use the chrome shim for now
+    if (window.webkitRTCPeerConnection) {
+      result.browser = 'chrome';
+      result.version = extractVersion(navigator.userAgent,
+        /Chrom(e|ium)\/(\d+)\./, 2);
+    } else { // Safari (in an unpublished version) or unknown webkit-based.
+      if (navigator.userAgent.match(/Version\/(\d+).(\d+)/)) {
+        result.browser = 'safari';
+        result.version = extractVersion(navigator.userAgent,
+          /AppleWebKit\/(\d+)\./, 1);
+      } else { // unknown webkit-based browser.
+        result.browser = 'Unsupported webkit-based browser ' +
+            'with GUM support but no WebRTC support.';
+        return result;
+      }
+    }
+  } else if (navigator.mediaDevices &&
+      navigator.userAgent.match(/Edge\/(\d+).(\d+)$/)) { // Edge.
+    result.browser = 'edge';
+    result.version = extractVersion(navigator.userAgent,
+        /Edge\/(\d+).(\d+)$/, 2);
+  } else if (navigator.mediaDevices &&
+      navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) {
+      // Safari, with webkitGetUserMedia removed.
+    result.browser = 'safari';
+    result.version = extractVersion(navigator.userAgent,
+        /AppleWebKit\/(\d+)\./, 1);
+  } else { // Default fallthrough: not supported.
+    result.browser = 'Not a supported browser.';
+    return result;
+  }
+
+  return result;
+}
+
+// shimCreateObjectURL must be called before shimSourceObject to avoid loop.
+
+export function shimCreateObjectURL(window) {
+  var URL = window && window.URL;
+
+  if (!(typeof window === 'object' && window.HTMLMediaElement &&
+        'srcObject' in window.HTMLMediaElement.prototype)) {
+    // Only shim CreateObjectURL using srcObject if srcObject exists.
+    return undefined;
+  }
+
+  var nativeCreateObjectURL = URL.createObjectURL.bind(URL);
+  var nativeRevokeObjectURL = URL.revokeObjectURL.bind(URL);
+  var streams = new Map(), newId = 0;
+
+  URL.createObjectURL = function(stream) {
+    if ('getTracks' in stream) {
+      var url = 'polyblob:' + (++newId);
+      streams.set(url, stream);
+      deprecated('URL.createObjectURL(stream)',
+          'elem.srcObject = stream');
+      return url;
+    }
+    return nativeCreateObjectURL(stream);
+  };
+  URL.revokeObjectURL = function(url) {
+    nativeRevokeObjectURL(url);
+    streams.delete(url);
+  };
+
+  var dsc = Object.getOwnPropertyDescriptor(window.HTMLMediaElement.prototype,
+                                            'src');
+  Object.defineProperty(window.HTMLMediaElement.prototype, 'src', {
+    get: function() {
+      return dsc.get.apply(this);
+    },
+    set: function(url) {
+      this.srcObject = streams.get(url) || null;
+      return dsc.set.apply(this, [url]);
+    }
+  });
+
+  var nativeSetAttribute = window.HTMLMediaElement.prototype.setAttribute;
+  window.HTMLMediaElement.prototype.setAttribute = function() {
+    if (arguments.length === 2 &&
+        ('' + arguments[0]).toLowerCase() === 'src') {
+      this.srcObject = streams.get(arguments[1]) || null;
+    }
+    return nativeSetAttribute.apply(this, arguments);
+  };
+}

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -39,16 +39,13 @@ if (process.env.CHROMEEXPERIMENT !== 'false') {
 module.exports = function(config) {
   config.set({
     basePath: '..',
-    frameworks: ['browserify', 'mocha', 'chai'],
+    frameworks: ['mocha', 'chai'],
     files: [
-      'src/js/adapter_core.js',
+      'out/adapter.js',
       'test/getusermedia-mocha.js',
       'test/e2e/*.js',
     ],
     exclude: [],
-    preprocessors: {
-      'src/js/adapter_core.js': ['browserify']
-    },
     reporters: ['mocha'],
     port: 9876,
     colors: true,
@@ -70,10 +67,5 @@ module.exports = function(config) {
     singleRun: true,
     concurrency: Infinity,
     browsers,
-    browserify: {
-      debug: true,
-      transform: ['brfs'],
-      standalone: 'adapter',
-    },
   });
 };

--- a/test/unit/adapter_factory.js
+++ b/test/unit/adapter_factory.js
@@ -6,16 +6,15 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
+import chai, {expect} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
-describe('adapter factory', () => {
-  const adapterFactory = require('../../src/js/adapter_factory.js');
-  const utils = require('../../src/js/utils.js');
+import adapterFactory from '../../src/js/adapter_factory.js';
+import * as utils from '../../src/js/utils.js';
 
+describe('adapter factory', () => {
   let window;
   beforeEach(() => {
     window = {

--- a/test/unit/chrome.js
+++ b/test/unit/chrome.js
@@ -6,11 +6,10 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
+import shim from '../../src/js/chrome/chrome_shim';
+import {expect} from 'chai';
 
 describe('Chrome shim', () => {
-  const shim = require('../../src/js/chrome/chrome_shim');
   let window;
 
   beforeEach(() => {

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -6,11 +6,10 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
+import {expect} from 'chai';
+import {detectBrowser} from '../../src/js/utils.js';
 
 describe('detectBrowser', () => {
-  const detectBrowser = require('../../src/js/utils.js').detectBrowser;
   let window;
   let navigator;
 

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -6,14 +6,15 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
-chai.use(sinonChai);
+import shim from '../../src/js/edge/edge_shim';
+import chai, {expect} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
 
-const SDPUtils = require('sdp');
-const EventEmitter = require('events');
+import SDPUtils from 'sdp';
+import EventEmitter from 'events';
+
+chai.use(sinonChai);
 
 function mockORTC(window) {
   // required by the shim to mock an EventEmitter.
@@ -137,7 +138,6 @@ function mockORTC(window) {
 }
 
 describe('Edge shim', () => {
-  const shim = require('../../src/js/edge/edge_shim');
   let window;
 
   const ua14392 = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -6,12 +6,10 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
+import {expect} from 'chai';
+import {extractVersion} from '../../src/js/utils.js';
 
 describe('extractVersion', () => {
-  const extractVersion = require('../../src/js/utils.js').extractVersion;
-
   let ua;
   describe('Chrome regular expression', () => {
     const expr = /Chrom(e|ium)\/(\d+)\./;
@@ -164,4 +162,3 @@ describe('extractVersion', () => {
     });
   });
 });
-

--- a/test/unit/firefox.js
+++ b/test/unit/firefox.js
@@ -6,11 +6,10 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
+import shim from '../../src/js/firefox/firefox_shim';
+import {expect} from 'chai';
 
 describe('Firefox shim', () => {
-  const shim = require('../../src/js/firefox/firefox_shim');
   let window;
 
   beforeEach(() => {

--- a/test/unit/getusermedia-constraints.js
+++ b/test/unit/getusermedia-constraints.js
@@ -6,14 +6,16 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
+import chromeShim from '../../src/js/chrome/getusermedia';
+import firefoxShim from '../../src/js/firefox/getusermedia';
+import chai, {expect} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
 chai.use(sinonChai);
 
 describe('Chrome getUserMedia constraints converter', () => {
-  const shim = require('../../src/js/chrome/getusermedia');
+  const shim = chromeShim;
   let window;
 
   beforeEach(() => {
@@ -133,7 +135,7 @@ describe('Chrome getUserMedia constraints converter', () => {
 });
 
 describe('Firefox getUserMedia constraints converter', () => {
-  const shim = require('../../src/js/firefox/getusermedia');
+  const shim = firefoxShim;
   let window;
 
   beforeEach(() => {

--- a/test/unit/logSuppression.js
+++ b/test/unit/logSuppression.js
@@ -6,12 +6,11 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
+import {expect} from 'chai';
+import * as utils from '../../src/js/utils.js';
 
 describe('Log suppression', () => {
-  const utils = require('../../src/js/utils.js');
-  const saveConsole = console.log.bind(console);
+  const saveConsole = console.log;
 
   let logCount;
   beforeEach(() => {
@@ -24,7 +23,6 @@ describe('Log suppression', () => {
       }
     };
     global.window = {};
-    require('../../out/adapter.js');
   });
 
   afterEach(() => {
@@ -36,6 +34,7 @@ describe('Log suppression', () => {
     utils.log('test');
     expect(logCount).to.equal(0);
   });
+
   it('does call console.log when enabled', () => {
     utils.disableLog(false);
     utils.log('test');

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -6,14 +6,14 @@
  *  tree.
  */
 /* eslint-env node */
-const chai = require('chai');
-const expect = chai.expect;
-const sinon = require('sinon');
-const sinonChai = require('sinon-chai');
+import shim from '../../src/js/safari/safari_shim';
+import chai, {expect} from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
 chai.use(sinonChai);
 
 describe('Safari shim', () => {
-  const shim = require('../../src/js/safari/safari_shim');
   let window;
 
   beforeEach(() => {


### PR DESCRIPTION
**Description**
Prefer static `import`/`export` declarations to the dynamic CommonJS `require` calls.

**Purpose**
We can transpile `import`/`export` into whatever module format users want to consume. It's not as easy to work with CommonJS, nor is it as easy to optimize. Using Rollup to produce the pre-built release bundles also results in slightly smaller output than Browserify.