### PR TITLE
Update Safari shim to handle window.URL.createObjectURL

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -93,7 +93,8 @@ module.exports = function(dependencies) {
       logging('adapter.js shimming safari.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = safariShim;
-
+      // shim window.URL.createObjectURL Safari (technical preview)
+      utils.shimCreateObjectURL(window);
       safariShim.shimCallbacksAPI(window);
       safariShim.shimLocalStreamsAPI(window);
       safariShim.shimRemoteStreamsAPI(window);


### PR DESCRIPTION
**Description**

Adds the shim for Safari (technical preview) to handle: window.URL.createObjectURL
