### PR TITLE
addTrack: synthetic ONN

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -114,8 +114,7 @@ var chromeShim = {
           var oldStream = pc._streams[stream.id];
           if (oldStream) {
             oldStream.addTrack(track);
-            pc.removeStream(oldStream);
-            pc.addStream(oldStream);
+            pc.dispatchEvent(new Event('negotiationneeded'));
           } else {
             var newStream = new window.MediaStream([track]);
             pc._streams[stream.id] = newStream;


### PR DESCRIPTION
fires ONN in JS instead of trying to make Chrome fire ONN (which it does too often)

This has a disadvantage though. In chrome://webrtc-internals addStream will only be called with an audio stream while before createOffer will be called in a state where the stream has both audio and video tracks.