### PR TITLE
safari: shim RTCIceServer.url and nag about it

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -22,7 +22,8 @@ module.exports = function(dependencies) {
   var adapter = {
     browserDetails: browserDetails,
     extractVersion: utils.extractVersion,
-    disableLog: utils.disableLog
+    disableLog: utils.disableLog,
+    disableWarnings: utils.disableWarnings
   };
 
   // Uncomment the line below if you want logging to occur, including logging

--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -96,6 +96,7 @@ module.exports = function(dependencies) {
       adapter.browserShim = safariShim;
       // shim window.URL.createObjectURL Safari (technical preview)
       utils.shimCreateObjectURL(window);
+      safariShim.shimRTCIceServerUrls(window);
       safariShim.shimCallbacksAPI(window);
       safariShim.shimLocalStreamsAPI(window);
       safariShim.shimRemoteStreamsAPI(window);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var logDisabled_ = true;
+var deprecationWarnings_ = true;
 
 // Utility methods.
 var utils = {
@@ -22,6 +23,19 @@ var utils = {
         'adapter.js logging enabled';
   },
 
+  /**
+   * Disable or enable deprecation warnings
+   * @param {!boolean} bool set to true to disable warnings.
+   */
+  disableWarnings: function(bool) {
+    if (typeof bool !== 'boolean') {
+      return new Error('Argument type: ' + typeof bool +
+          '. Please use a boolean.');
+    }
+    deprecationWarnings_ = !bool;
+    return 'adapter.js deprecation warnings ' + (bool ? 'disabled' : 'enabled');
+  },
+
   log: function() {
     if (typeof window === 'object') {
       if (logDisabled_) {
@@ -31,6 +45,17 @@ var utils = {
         console.log.apply(console, arguments);
       }
     }
+  },
+
+  /**
+   * Shows a deprecation warning suggesting the modern and spec-compatible API.
+   */
+  deprecated: function(oldMethod, newMethod) {
+    if (!deprecationWarnings_) {
+      return;
+    }
+    console.warn(oldMethod + ' is deprecated, please use ' + newMethod +
+        ' instead.');
   },
 
   /**
@@ -126,8 +151,8 @@ var utils = {
       if ('getTracks' in stream) {
         var url = 'polyblob:' + (++newId);
         streams.set(url, stream);
-        console.log('URL.createObjectURL(stream) is deprecated! ' +
-                    'Use elem.srcObject = stream instead!');
+        utils.deprecated('URL.createObjectURL(stream)',
+            'elem.srcObject = stream');
         return url;
       }
       return nativeCreateObjectURL(stream);
@@ -163,7 +188,9 @@ var utils = {
 // Export.
 module.exports = {
   log: utils.log,
+  deprecated: utils.deprecated,
   disableLog: utils.disableLog,
+  disableWarnings: utils.disableWarnings,
   extractVersion: utils.extractVersion,
   shimCreateObjectURL: utils.shimCreateObjectURL,
   detectBrowser: utils.detectBrowser.bind(utils)

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -18,7 +18,7 @@ describe('Safari shim', () => {
 
   beforeEach(() => {
     window = {
-      RTCPeerConnection: function() {}
+      RTCPeerConnection: sinon.stub()
     };
   });
 
@@ -129,6 +129,59 @@ describe('Safari shim', () => {
           pc[method](null, null, 1, 2);
           expect(stub).to.have.been.calledWith(1);
         });
+      });
+    });
+  });
+  describe('conversion of RTCIceServer.url', () => {
+    let nativeStub;
+    beforeEach(() => {
+      nativeStub = window.RTCPeerConnection;
+      shim.shimRTCIceServerUrls(window);
+    });
+
+    const stunURL = 'stun:stun.l.google.com:19302';
+    const url = {url: stunURL};
+    const urlArray = {url: [stunURL]};
+    const urls = {urls: stunURL};
+    const urlsArray = {urls: [stunURL]};
+
+    describe('does not modify RTCIceServer.urls', () => {
+      it('for strings', () => {
+        new window.RTCPeerConnection({iceServers: [urls]});
+        expect(nativeStub).to.have.been.calledWith(sinon.match({
+          iceServers: sinon.match([
+            sinon.match(urls)
+          ])
+        }));
+      });
+
+      it('for arrays', () => {
+        new window.RTCPeerConnection({iceServers: [urlsArray]});
+        expect(nativeStub).to.have.been.calledWith(sinon.match({
+          iceServers: sinon.match([
+            sinon.match(urlsArray)
+          ])
+        }));
+      });
+    });
+
+    describe('transforms RTCIceServer.url to RTCIceServer.urls', () => {
+      it('for strings', () => {
+        new window.RTCPeerConnection({iceServers: [url]});
+        expect(nativeStub).to.have.been.calledWith(sinon.match({
+          iceServers: sinon.match([
+            sinon.match(urls)
+          ])
+        }));
+      });
+
+      it('for arrays', () => {
+        new window.RTCPeerConnection({iceServers: [urlArray]});
+        expect(nativeStub).to.have.been.calledWith(sinon.match({
+          iceServers: sinon.match([
+            sinon.match(urlsArray)
+          ])
+        }));
       });
     });
   });


### PR DESCRIPTION
(depends on #572)

Safari does not natively support RTCIceServer.url.
<img width="331" alt="url" src="https://user-images.githubusercontent.com/289731/27002118-50a8e642-4dd9-11e7-804d-579edfb888c0.png">

Shim it and nag users to update. Code is copied from the Chrome shim that does the same job but deletes RTCIceServer.url

@youennf please take a look. Also 👏 for enforcing the spec