### PR TITLE
Use session ID for each peer connection on Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "grunt && mocha test/unit && node test/run-tests.js"
   },
   "dependencies": {
-    "sdp": "git://github.com/armouroflight/sdp.git#cc26d22"
+    "sdp": "^2.1.0"
   },
   "engines": {
     "npm": ">=3.10.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "grunt && mocha test/unit && node test/run-tests.js"
   },
   "dependencies": {
-    "sdp": "^1.5.0"
+    "sdp": "git://github.com/armouroflight/sdp.git#cc26d22"
   },
   "engines": {
     "npm": ">=3.10.0",

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -237,6 +237,8 @@ module.exports = function(window, edgeVersion) {
     // must not emit candidates until after setLocalDescription we buffer
     // them in this array.
     this._localIceCandidatesBuffer = [];
+
+    this._sdpSessionId = SDPUtils.generateSessionId();
   };
 
   RTCPeerConnection.prototype._emitGatheringStateChange = function() {
@@ -1153,7 +1155,7 @@ module.exports = function(window, edgeVersion) {
     // reorder tracks
     var transceivers = sortTracks(this.transceivers);
 
-    var sdp = SDPUtils.writeSessionBoilerplate();
+    var sdp = SDPUtils.writeSessionBoilerplate(this._sdpSessionId);
     transceivers.forEach(function(transceiver, sdpMLineIndex) {
       // For each track, create an ice gatherer, ice transport,
       // dtls transport, potentially rtpsender and rtpreceiver.

--- a/src/js/edge/rtcpeerconnection_shim.js
+++ b/src/js/edge/rtcpeerconnection_shim.js
@@ -1238,7 +1238,7 @@ module.exports = function(window, edgeVersion) {
   };
 
   RTCPeerConnection.prototype.createAnswer = function() {
-    var sdp = SDPUtils.writeSessionBoilerplate();
+    var sdp = SDPUtils.writeSessionBoilerplate(this._sdpSessionId);
     if (this.usingBundle) {
       sdp += 'a=group:BUNDLE ' + this.transceivers.map(function(t) {
         return t.mid;


### PR DESCRIPTION
We have seen that the adapter.js currently uses the same hardcoded session ID for all SDP.  This makes it a random session ID for each RTCPeerConnection which is like other browsers have been seen to do.

This change relies on changes in sdp.js which I have put in a PR for.  Let me know if you need any more details.