### PR TITLE
travis: add chrome stable/beta without experiments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ env:
 
   matrix:
     - BROWSER=chrome  BVER=stable
+    - BROWSER=chrome  BVER=stable CHROMEEXPERIMENT=false
     - BROWSER=chrome  BVER=beta
+    - BROWSER=chrome  BVER=beta CHROMEEXPERIMENT=false
     - BROWSER=chrome  BVER=unstable
     - BROWSER=firefox BVER=stable
     - BROWSER=firefox BVER=beta

--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -81,7 +81,7 @@ function buildDriver() {
 
   if (process.env.BROWSER === 'chrome') {
     let browserVersion = getBrowserVersion();
-    if (browserVersion >= 49) {
+    if (browserVersion >= 49 && process.env.CHROMEEXPERIMENT !== 'false') {
       chromeOptions.addArguments('--enable-experimental-web-platform-features');
     }
     if (browserVersion >= 59) {


### PR DESCRIPTION
Since users do not run chrome stable or beta with the
experimental web platform features flag on we should
also reflect this in our chrome test environment.