### PR TITLE
test: support travis multirunner BVER in selenium lib

### DIFF
--- a/test/selenium-lib.js
+++ b/test/selenium-lib.js
@@ -93,7 +93,9 @@ function buildDriver() {
   var edgeOptions = new edge.Options();
 
   var safariOptions = new safari.Options();
-  safariOptions.setTechnologyPreview(process.env.BVER === 'TechnologyPreview');
+  safariOptions.setTechnologyPreview(
+      process.env.BVER === 'TechnologyPreview' ||
+      process.env.BVER === 'unstable');
 
   sharedDriver = new webdriver.Builder()
       .forBrowser(process.env.BROWSER)


### PR DESCRIPTION
supports both variants of BVER for safari technology preview -- unstable coming from https://github.com/DamonOehlman/travis-multirunner/pull/23