### PR TITLE
test: set SAFARI_BIN in karma.conf

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -27,6 +27,13 @@ if (process.env.BROWSER) {
   browsers = ['chrome', 'firefox'];
 }
 
+// uses Safari Technology Preview.
+if (os.platform() === 'darwin' && process.env.BVER === 'unstable' &&
+    !process.env.SAFARI_BIN) {
+  process.env.SAFARI_BIN = '/Applications/Safari Technology Preview.app' +
+      '/Contents/MacOS/Safari Technology Preview';
+}
+
 let chromeFlags = [
   '--use-fake-device-for-media-stream',
   '--use-fake-ui-for-media-stream',


### PR DESCRIPTION
sets SAFARI_BIN to point to Safari Technology Preview
when BVER is set to experimental. This makes karma tests run in STP.
