### PR TITLE
test: provide expected karma run results as files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.3",
     "karma-safari-launcher": "^1.0.0",
+    "karma-stability-reporter": "git+https://github.com/fippo/karma-stability-reporter.git#v1.0.0",
     "mocha": "^3.2.0",
     "selenium-webdriver": "3.3.0",
     "sinon": "^2.2.0",

--- a/test/e2e/dtmf.js
+++ b/test/e2e/dtmf.js
@@ -25,8 +25,6 @@ describe('dtmf', () => {
       });
     });
 
-    /* Broken in Firefox 54 */
-    /*
     it('does not exist on video senders', () => {
       const pc = new RTCPeerConnection();
       return navigator.mediaDevices.getUserMedia({video: true})
@@ -37,7 +35,6 @@ describe('dtmf', () => {
         expect(dtmf).to.equal(null);
       });
     });
-    */
   });
 
   describe('inserts DTMF', () => {

--- a/test/e2e/expectations/MicrosoftEdge
+++ b/test/e2e/expectations/MicrosoftEdge
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+SKIP establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+ERR track event RTCPeerConnection.prototype.ontrack exists AssertionError
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+PASS dtmf RTCRtpSender.dtmf does not exist on video senders
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+ERR dtmf RTCRtpSender.dtmf does not exist on video senders AssertionError
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+ERR dtmf RTCRtpSender.dtmf does not exist on video senders AssertionError
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -1,0 +1,38 @@
+PASS addTrack and getSenders creates a sender
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+ERR dtmf RTCRtpSender.dtmf does not exist on video senders AssertionError
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -1,0 +1,37 @@
+PASS window.adapter exists
+PASS window.adapter browserDetails exists
+PASS window.adapter browserDetails detects a browser type
+PASS window.adapter browserDetails detects a browser version
+PASS establishes a connection with legacy callbacks
+PASS establishes a connection with promises
+PASS establishes a connection with streams in both directions
+PASS establishes a connection with no explicit end-of-candidates
+PASS establishes a connection and calls the video loadedmetadata
+PASS establishes a connection with addTrack and all tracks of a stream
+PASS establishes a connection with addTrack but only the audio track of an av stream
+PASS establishes a connection with addTrack as two streams
+PASS establishes a connection with datachannel establishes a connection
+PASS dtmf RTCRtpSender.dtmf exists on audio senders
+ERR dtmf RTCRtpSender.dtmf does not exist on video senders AssertionError
+PASS dtmf inserts DTMF when using addStream
+PASS dtmf inserts DTMF when using addTrack
+PASS getUserMedia navigator.getUserMedia exists
+PASS getUserMedia navigator.getUserMedia calls the callback
+PASS getUserMedia navigator.mediaDevices.getUserMedia exists
+PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS MediaStream window.MediaStream exists
+PASS track event RTCPeerConnection.prototype.ontrack exists
+SKIP track event is called by setRemoteDescription track event
+PASS track event is called by setRemoteDescription ontrack
+PASS track event the event has a track
+PASS track event the event has a set of streams
+PASS track event the event has a receiver that is contained in the set of receivers
+PASS RTCIceCandidate window.RTCIceCandidate exists
+PASS RTCPeerConnection window.RTCPeerConnection exists
+PASS RTCPeerConnection constructor works
+PASS RTCPeerConnection getSenders exists
+PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setter triggers loadedmetadata (audio)
+PASS srcObject getter returns the stream (audio)
+PASS srcObject setter triggers loadedmetadata (video)
+PASS srcObject getter returns the stream (video)

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -27,6 +27,13 @@ if (process.env.BROWSER) {
   browsers = ['chrome', 'firefox'];
 }
 
+let reporters = ['mocha'];
+if (process.env.CI) {
+  // stability must be the last reporter as it munges the
+  // exit code and always returns 0.
+  reporters.push('stability');
+}
+
 // uses Safari Technology Preview.
 if (os.platform() === 'darwin' && process.env.BVER === 'unstable' &&
     !process.env.SAFARI_BIN) {
@@ -56,7 +63,7 @@ module.exports = function(config) {
     preprocessors: {
       'src/js/adapter_core.js': ['browserify']
     },
-    reporters: [process.env.CI ? 'stability' : 'mocha'],
+    reporters,
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -56,7 +56,7 @@ module.exports = function(config) {
     preprocessors: {
       'src/js/adapter_core.js': ['browserify']
     },
-    reporters: ['mocha'],
+    reporters: [process.env.CI ? 'stability' : 'mocha'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,
@@ -82,5 +82,12 @@ module.exports = function(config) {
       transform: ['brfs'],
       standalone: 'adapter',
     },
+    stabilityReporter: {
+      path: 'test/e2e/expectations/' +
+          process.env.BROWSER +
+          (process.env.BVER ? '-' + process.env.BVER : '') +
+          (process.env.CHROMEEXPERIMENT === 'false' ? '-no-experimental' : ''),
+      update: false,
+    }
   });
 };


### PR DESCRIPTION
this allows comparing the results of a testsuite run to a previous run.
Also re-enables the "no dtmf sender on video rtpsenders" test which was broken in Firefox but that is now a "known failure".

We'll see how that goes moving forward. Might be a bit too much effort updating those files all the time.
To update them, run the karma test for all browsers that need updating with stabilityReporter.update set to true.