### PR TITLE
Use simple object assignment instead of Object.assign 

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -13,12 +13,18 @@
 module.exports = function(dependencies, opts) {
   var window = dependencies && dependencies.window;
 
-  var options = Object.assign({
+  var options = {
     shimChrome: true,
     shimFirefox: true,
     shimEdge: true,
     shimSafari: true,
-  }, opts);
+  };
+
+  for (var key in opts) {
+    if (hasOwnProperty.call(opts, key)) {
+      options[key] = opts[key];
+    }
+  }
 
   // Utils.
   var utils = require('./utils');


### PR DESCRIPTION
which crashes shimming in phantom

**Description**

This PR switches the initial options assignment from `Object.assign` to simple property assignment.

**Purpose**

Prior to version 4.x, the script could be loaded in phantom.js/IE/Safari without crashing. As of 4.x, the use of `Object.assign` (which does not exist in these browsers) causes an exception to be thrown immediately upon loading adapter.js. 

