### PR TITLE
test: make addIceCandidate test work in Edge

### DIFF
--- a/test/e2e/addIceCandidate.js
+++ b/test/e2e/addIceCandidate.js
@@ -32,7 +32,11 @@ describe('addIceCandidate', () => {
         'a=msid:stream1 track1\r\n' +
         'a=ssrc:1001 cname:some\r\n';
     pc = new RTCPeerConnection();
-    return pc.setRemoteDescription({type: 'offer', sdp});
+    return pc.setRemoteDescription({type: 'offer', sdp})
+    .then(() => {
+      return pc.addIceCandidate({sdpMid: 'mid1', candidate:
+          'candidate:702786350 1 udp 41819902 8.8.8.8 60769 typ host'});
+    });
   });
   afterEach(() => {
     pc.close();

--- a/test/e2e/expectations/MicrosoftEdge
+++ b/test/e2e/expectations/MicrosoftEdge
@@ -1,3 +1,5 @@
+PASS addIceCandidate after setRemoteDescription resolves when called with null
+PASS addIceCandidate after setRemoteDescription resolves when called with undefined
 ERR addTrack throws an exception if the track has already been added AssertionError
 ERR addTrack throws an exception if the track has already been added via addStream AssertionError
 ERR addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
@@ -19,16 +21,31 @@ PASS establishes a connection with addTrack and all tracks of a stream
 PASS establishes a connection with addTrack but only the audio track of an av stream
 PASS establishes a connection with addTrack as two streams
 SKIP establishes a connection with datachannel establishes a connection
+PASS URL.createObjectURL shim works for audio using src=
+PASS URL.createObjectURL shim works for audio using setAttribute
+PASS URL.createObjectURL shim works for video using src=
+PASS URL.createObjectURL shim works for video using setAttribute
 PASS dtmf RTCRtpSender.dtmf exists on audio senders
 PASS dtmf RTCRtpSender.dtmf does not exist on video senders
 PASS dtmf inserts DTMF when using addStream
 PASS dtmf inserts DTMF when using addTrack
+PASS getStats returns a Promise
+PASS getStats resolves the Promise with a Map(like)
 PASS getUserMedia navigator.getUserMedia exists
 PASS getUserMedia navigator.getUserMedia calls the callback
-PASS getUserMedia navigator.mediaDevices.getUserMedia exists
-PASS getUserMedia navigator.mediaDevices.getUserMedia fulfills the promise
+PASS navigator.mediaDevices exists
+PASS navigator.mediaDevices is an EventTarget
+PASS navigator.mediaDevices implements the devicechange event
+PASS navigator.mediaDevices getUserMedia exists
+PASS navigator.mediaDevices getUserMedia fulfills the promise
+PASS navigator.mediaDevices enumerateDevices exists
+PASS navigator.mediaDevices enumerateDevices returns an array of devices
+PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
+PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
+PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
 ERR track event RTCPeerConnection.prototype.ontrack exists AssertionError
+PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event
 PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
@@ -51,7 +68,10 @@ PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works
 PASS RTCPeerConnection getSenders exists
 ERR RTCPeerConnection generateCertificate is a static method AssertionError
+PASS RTCPeerConnection icegatheringstatechange fires the event
+PASS RTCPeerConnection icegatheringstatechange calls the event handler
 PASS RTCSessionDescription window.RTCSessionDescription exists
+PASS srcObject setting from another object works
 PASS srcObject setter triggers loadedmetadata (audio)
 PASS srcObject getter returns the stream (audio)
 PASS srcObject setter triggers loadedmetadata (video)


### PR DESCRIPTION
the addIceCandidate test caused an exception in Edge since addRemoteCandidate({})
was called without any real candidates.

Also updates the expectation file.