### PR TITLE
chrome: munge sdp to keep stream ids

### DIFF
--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -44,6 +44,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
+PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called by setRemoteDescription during renegotiation
 PASS track event is called by setRemoteDescription track event

--- a/test/e2e/msid.js
+++ b/test/e2e/msid.js
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+describe('MSID', () => {
+  let pc1;
+  let pc2;
+
+  function negotiate(pc, otherPc) {
+    return pc.createOffer()
+    .then(function(offer) {
+      return pc.setLocalDescription(offer);
+    }).then(function() {
+      return otherPc.setRemoteDescription(pc.localDescription);
+    }).then(function() {
+      return otherPc.createAnswer();
+    }).then(function(answer) {
+      return otherPc.setLocalDescription(answer);
+    }).then(function() {
+      return pc.setRemoteDescription(otherPc.localDescription);
+    });
+  }
+
+  beforeEach(() => {
+    pc1 = new RTCPeerConnection(null);
+    pc2 = new RTCPeerConnection(null);
+
+    pc1.onicecandidate = event => pc2.addIceCandidate(event.candidate);
+    pc2.onicecandidate = event => pc1.addIceCandidate(event.candidate);
+  });
+  afterEach(() => {
+    pc1.close();
+    pc2.close();
+  });
+
+  it('signals track and stream ids', (done) => {
+    let localStream;
+    pc2.ontrack = (e) => {
+      expect(e.track.id).to.equal(localStream.getTracks()[0].id);
+      expect(e.streams[0].id).to.equal(localStream.id);
+      done();
+    };
+    navigator.mediaDevices.getUserMedia({video: true})
+    .then((stream) => {
+      localStream = stream;
+      pc1.addTrack(stream.getTracks()[0], stream);
+      return negotiate(pc1, pc2);
+    });
+  });
+});


### PR DESCRIPTION
munges the SDP in createOffer, createAnswer and setLocalDescription as well
as the pc.localDescription accessor in order to retain the stream ids that
are modifed by the addTrack shim.

Fixes #634 

@henbos can you take a look? I tried to mangle the getStats result too but that didn't work :-/
