### PR TITLE
travis: allow firefox beta to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
     - env: BROWSER=firefox BVER=nightly
+    - env: BROWSER=firefox BVER=beta
 
 before_script:
   - ./node_modules/travis-multirunner/setup.sh


### PR DESCRIPTION
firefox 55+ currently times out when trying to fetch file:// urls
which causes the selenium tests to fail. Allow travis failure.