### PR TITLE
Shim event.transceiver.

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -116,6 +116,7 @@ module.exports = function(dependencies, opts) {
       safariShim.shimCallbacksAPI(window);
       safariShim.shimLocalStreamsAPI(window);
       safariShim.shimRemoteStreamsAPI(window);
+      safariShim.shimTrackEventTransceiver(window);
       safariShim.shimGetUserMedia(window);
       break;
     default:

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -51,6 +51,7 @@ var chromeShim = {
               var event = new Event('track');
               event.track = te.track;
               event.receiver = receiver;
+              event.transceiver = {receiver: receiver};
               event.streams = [e.stream];
               pc.dispatchEvent(event);
             });
@@ -66,6 +67,7 @@ var chromeShim = {
               var event = new Event('track');
               event.track = track;
               event.receiver = receiver;
+              event.transceiver = {receiver: receiver};
               event.streams = [e.stream];
               pc.dispatchEvent(event);
             });

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -29,10 +29,20 @@ var firefoxShim = {
               var event = new Event('track');
               event.track = track;
               event.receiver = {track: track};
+              event.transceiver = {receiver: event.receiver};
               event.streams = [e.stream];
               this.dispatchEvent(event);
             }.bind(this));
           }.bind(this));
+        }
+      });
+    }
+    if (typeof window === 'object' && window.RTCPeerConnection &&
+        ('receiver' in window.RTCTrackEvent.prototype) &&
+        !('transceiver' in window.RTCTrackEvent.prototype)) {
+      Object.defineProperty(window.RTCTrackEvent.prototype, 'transceiver', {
+        get: function() {
+          return {receiver: this.receiver};
         }
       });
     }

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -236,6 +236,20 @@ var safariShim = {
         return OrigPeerConnection.generateCertificate;
       }
     });
+  },
+  shimTrackEventTransceiver: function(window) {
+    // Add event.transceiver member over deprecated event.receiver
+    if (typeof window === 'object' && window.RTCPeerConnection &&
+        ('receiver' in window.RTCTrackEvent.prototype) &&
+        // can't check 'transceiver' in window.RTCTrackEvent.prototype, as it is
+        // defined for some reason even when window.RTCTransceiver is not.
+        !window.RTCTransceiver) {
+      Object.defineProperty(window.RTCTrackEvent.prototype, 'transceiver', {
+        get: function() {
+          return {receiver: this.receiver};
+        }
+      });
+    }
   }
 };
 
@@ -245,7 +259,8 @@ module.exports = {
   shimLocalStreamsAPI: safariShim.shimLocalStreamsAPI,
   shimRemoteStreamsAPI: safariShim.shimRemoteStreamsAPI,
   shimGetUserMedia: safariShim.shimGetUserMedia,
-  shimRTCIceServerUrls: safariShim.shimRTCIceServerUrls
+  shimRTCIceServerUrls: safariShim.shimRTCIceServerUrls,
+  shimTrackEventTransceiver: safariShim.shimTrackEventTransceiver
   // TODO
   // shimPeerConnection: safariShim.shimPeerConnection
 };

--- a/test/e2e/expectations/MicrosoftEdge
+++ b/test/e2e/expectations/MicrosoftEdge
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 ERR removeTrack allows removeTrack twice timeout
 ERR removeTrack throws an exception if the argument is a track, not a sender AssertionError
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -51,6 +51,7 @@ PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track
 PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
+PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError

--- a/test/e2e/ontrack.js
+++ b/test/e2e/ontrack.js
@@ -78,7 +78,17 @@ describe('track event', () => {
     it('a receiver that is contained in the set of receivers', (done) => {
       pc.ontrack = (e) => {
         expect(e).to.have.property('receiver');
+        expect(e.receiver.track).to.equal(e.track);
         expect(pc.getReceivers()).to.contain(e.receiver);
+        done();
+      };
+      pc.setRemoteDescription({type: 'offer', sdp});
+    });
+    it('a transceiver that has a receiver', (done) => {
+      pc.ontrack = (e) => {
+        expect(e).to.have.property('transceiver');
+        expect(e.transceiver).to.have.property('receiver');
+        expect(e.transceiver.receiver).to.equal(e.receiver);
         done();
       };
       pc.setRemoteDescription({type: 'offer', sdp});


### PR DESCRIPTION
**Description**
Shim `event.transceiver` on older browsers (i.e. all of them at this point).

**Purpose**
Let's us consider removing redundant `event.receiver`. in favor of `event.transceiver.receiver`.