### PR TITLE
test: use headless firefox

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -87,7 +87,8 @@ module.exports = function(config) {
         prefs: {
           'media.navigator.streams.fake': true,
           'media.navigator.permission.disabled': true
-        }
+        },
+        flags: ['-headless']
       }
     },
     singleRun: true,


### PR DESCRIPTION
uses headless firefox which is described in
    https://developer.mozilla.org/en-US/Firefox/Headless_mode

We still need xvfb for the time being due to firefox ESR