### PR TITLE
chrome: override addtrack because of bugs

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -228,8 +228,10 @@ var chromeShim = {
   },
 
   shimAddTrackRemoveTrack: function(window) {
+    var browserDetails = utils.detectBrowser(window);
     // shim addTrack and removeTrack.
-    if (window.RTCPeerConnection.prototype.addTrack) {
+    if (window.RTCPeerConnection.prototype.addTrack &&
+        browserDetails.version >= 62) {
       return;
     }
 

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -2,12 +2,12 @@ PASS addIceCandidate after setRemoteDescription resolves when called with null
 PASS addIceCandidate after setRemoteDescription resolves when called with undefined
 PASS addTrack throws an exception if the track has already been added
 PASS addTrack throws an exception if the track has already been added via addStream
-ERR addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
+PASS addTrack throws an exception if addStream is called with a stream containing a track already added
 PASS addTrack throws an exception if the peerconnection has been closed already
 PASS addTrack and getSenders creates a sender
-ERR addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added AssertionError
-ERR addTrack and getLocalStreams adds another track to the same stream AssertionError
-ERR addTrack and getLocalStreams plays together nicely AssertionError
+PASS addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added
+PASS addTrack and getLocalStreams adds another track to the same stream
+PASS addTrack and getLocalStreams plays together nicely
 PASS window.adapter exists
 PASS window.adapter browserDetails exists
 PASS window.adapter browserDetails detects a browser type
@@ -28,7 +28,7 @@ PASS URL.createObjectURL shim works for video using setAttribute
 PASS dtmf RTCRtpSender.dtmf exists on audio senders
 PASS dtmf RTCRtpSender.dtmf does not exist on video senders
 PASS dtmf inserts DTMF when using addStream
-ERR dtmf inserts DTMF when using addTrack timeout
+PASS dtmf inserts DTMF when using addTrack
 PASS getStats returns a Promise
 PASS getStats resolves the Promise with a Map(like)
 PASS getUserMedia navigator.getUserMedia exists
@@ -54,15 +54,15 @@ PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
 PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
-ERR removeTrack throws an exception if the argument is a track, not a sender AssertionError
+PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
 PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
+PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
 PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
-ERR removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched AssertionError
+PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -2,12 +2,12 @@ PASS addIceCandidate after setRemoteDescription resolves when called with null
 PASS addIceCandidate after setRemoteDescription resolves when called with undefined
 PASS addTrack throws an exception if the track has already been added
 PASS addTrack throws an exception if the track has already been added via addStream
-ERR addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
+PASS addTrack throws an exception if addStream is called with a stream containing a track already added
 PASS addTrack throws an exception if the peerconnection has been closed already
 PASS addTrack and getSenders creates a sender
-ERR addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added AssertionError
-ERR addTrack and getLocalStreams adds another track to the same stream AssertionError
-ERR addTrack and getLocalStreams plays together nicely AssertionError
+PASS addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added
+PASS addTrack and getLocalStreams adds another track to the same stream
+PASS addTrack and getLocalStreams plays together nicely
 PASS window.adapter exists
 PASS window.adapter browserDetails exists
 PASS window.adapter browserDetails detects a browser type
@@ -28,7 +28,7 @@ PASS URL.createObjectURL shim works for video using setAttribute
 PASS dtmf RTCRtpSender.dtmf exists on audio senders
 PASS dtmf RTCRtpSender.dtmf does not exist on video senders
 PASS dtmf inserts DTMF when using addStream
-ERR dtmf inserts DTMF when using addTrack timeout
+PASS dtmf inserts DTMF when using addTrack
 PASS getStats returns a Promise
 PASS getStats resolves the Promise with a Map(like)
 PASS getUserMedia navigator.getUserMedia exists
@@ -54,15 +54,15 @@ PASS track event the event has a set of streams
 PASS track event the event has a receiver that is contained in the set of receivers
 ERR track event the event has a transceiver that has a receiver timeout
 PASS removeTrack allows removeTrack twice
-ERR removeTrack throws an exception if the argument is a track, not a sender AssertionError
+PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
 PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
+PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
 PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
-ERR removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched AssertionError
+PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists


### PR DESCRIPTION
the native addTrack (which is in chrome stable behind a flag) seems to have
some issues with video freezes:
    https://bugs.chromium.org/p/chromium/issues/detail?id=762527
overrides with the shim until this can be fixed.

@henbos PTAL (once CI is green)
