### PR TITLE
safari: shim legacy offerToReceive*

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -125,6 +125,7 @@ module.exports = function(dependencies, opts) {
       safariShim.shimRemoteStreamsAPI(window);
       safariShim.shimTrackEventTransceiver(window);
       safariShim.shimGetUserMedia(window);
+      safariShim.shimCreateOfferLegacy(window);
 
       commonShim.shimRTCIceCandidate(window);
       break;


### PR DESCRIPTION
shims offerToReceive in Safari to behave similar to how it behaves in other
browsers. Most importantly this means creating a transceiver on peerconnections
that have no local streams but call `createOffer({offerToReceiveVideo: true})`

Roughly https://github.com/fippo/adapter/tree/offerToReceive but without the e2e tests. The behaviour of createOffer({offerToReceive*: false}) is discussed [here](https://github.com/w3c/webrtc-pc/issues/1586) (and in linked PRs) but the tests would fail due to [this bug](https://bugs.webkit.org/show_bug.cgi?id=176665)

@youennf can you take a look? 
@jan-ivar can you check if the code is in line with your latest spec PRs?