### PR TITLE
chrome: fix leaking _stream in removeStream

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -142,7 +142,7 @@ var chromeShim = {
       window.RTCPeerConnection.prototype.removeStream = function(stream) {
         var pc = this;
         pc._senders = pc._senders || [];
-        origRemoveStream.apply(pc, [(pc._streams[stream.id] || stream)]);
+        origRemoveStream.apply(pc, [stream]);
 
         stream.getTracks().forEach(function(track) {
           var sender = pc._senders.find(function(s) {


### PR DESCRIPTION
calls origRemoveStream with the external stream so that
it gets removed from pc._streams

Otherwise the following will still hold:
```
pc.addStream(stream);
pc.removeStream(stream);
Object.keys(pc._streams).length === 1
```