### PR TITLE
fix #683 RTCPeerConnection.getStats(mediaStreamTrack, callback) does not work correct

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -538,7 +538,7 @@ var chromeShim = {
       // When spec-style getStats is supported, return those when called with
       // either no arguments or the selector argument is null.
       if (origGetStats.length === 0 && (arguments.length === 0 ||
-          typeof arguments[0] !== 'function')) {
+          selector == null)) {
         return origGetStats.apply(this, []);
       }
 


### PR DESCRIPTION
**Description**
The full [desc](https://github.com/webrtc/adapter/issues/683)
```js
      // When spec-style getStats is supported, return those when called with
      // either no arguments or the selector argument is null.
      if (origGetStats.length === 0 && (arguments.length === 0 ||
          typeof arguments[0] !== 'function')) {
        return origGetStats.apply(this, []);
      }
```
As we can see the comment contradicts the code.
or the selector argument is null. and typeof arguments[0] !== 'function'

**Purpose**
When I call `RTCPeerConnection.getStats(mediaStreamTrack, callback)` I would like to be here:  
`return origGetStats.apply(this, [successCallbackWrapper_, arguments[0]]);`
