### PR TITLE
safari: small fixes in offerToReceive

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -264,9 +264,9 @@ var safariShim = {
               transceiver.sender.track.kind === 'audio';
         });
         if (offerOptions.offerToReceiveAudio === false && audioTransceiver) {
-          if (audioTransceiver.getDirection() === 'sendrecv') {
+          if (audioTransceiver.direction === 'sendrecv') {
             audioTransceiver.setDirection('sendonly');
-          } else if (audioTransceiver.getDirection() === 'recvonly') {
+          } else if (audioTransceiver.direction === 'recvonly') {
             audioTransceiver.setDirection('inactive');
           }
         } else if (offerOptions.offerToReceiveAudio === true &&
@@ -279,9 +279,9 @@ var safariShim = {
               transceiver.sender.track.kind === 'video';
         });
         if (offerOptions.offerToReceiveVideo === false && videoTransceiver) {
-          if (videoTransceiver.getDirection() === 'sendrecv') {
+          if (videoTransceiver.direction === 'sendrecv') {
             videoTransceiver.setDirection('sendonly');
-          } else if (audioTransceiver.getDirection() === 'recvonly') {
+          } else if (videoTransceiver.direction === 'recvonly') {
             videoTransceiver.setDirection('inactive');
           }
         } else if (offerOptions.offerToReceiveVideo === true &&


### PR DESCRIPTION
**Description**
Safari doesn't seem to implement transceiver.getDirection() function and the library throws an error if we try to call it.

Also fix a wrong access to audioTransceiver when we wanted to use videoTransceiver.