### PR TITLE
chrome: don't shim getUserMedia constraints in chrome 61+

### DIFF
--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -67,6 +67,9 @@ module.exports = function(window) {
   };
 
   var shimConstraints_ = function(constraints, func) {
+    if (browserDetails.version >= 61) {
+      return func(constraints);
+    }
     constraints = JSON.parse(JSON.stringify(constraints));
     if (constraints && typeof constraints.audio === 'object') {
       var remap = function(obj, a, b) {


### PR DESCRIPTION
fixes #553. Since this is a rather drastic change in behaviour
this should be a major version bump.

based on top of the bandaid one, can rebase after merge