### PR TITLE
firefox: shim removeStream

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -90,6 +90,7 @@ module.exports = function(dependencies, opts) {
       firefoxShim.shimSourceObject(window);
       firefoxShim.shimPeerConnection(window);
       firefoxShim.shimOnTrack(window);
+      firefoxShim.shimRemoveStream(window);
 
       commonShim.shimRTCIceCandidate(window);
       break;

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -196,6 +196,20 @@ var firefoxShim = {
         })
         .then(onSucc, onErr);
     };
+  },
+
+  shimRemoveStream: function(window) {
+    if ('removeStream' in window.RTCPeerConnection.prototype) {
+      return;
+    }
+    window.RTCPeerConnection.prototype.removeStream = function(stream) {
+      utils.deprecated('removeStream', 'removeTrack');
+      this.getSenders().forEach(function(sender) {
+        if (sender.track && stream.getTracks().indexOf(sender.track) !== -1) {
+          this.removeTrack(sender);
+        }
+      });
+    };
   }
 };
 
@@ -204,5 +218,6 @@ module.exports = {
   shimOnTrack: firefoxShim.shimOnTrack,
   shimSourceObject: firefoxShim.shimSourceObject,
   shimPeerConnection: firefoxShim.shimPeerConnection,
+  shimRemoveStream: firefoxShim.shimRemoveStream,
   shimGetUserMedia: require('./getusermedia')
 };


### PR DESCRIPTION
shims removeStream as a polyfill using removeTrack in Firefox
while emitting a deprecation warning.

cc @nils-ohlmeier