### PR TITLE
Bumped version number for shimAddTrackRemoveTrack

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -231,7 +231,7 @@ var chromeShim = {
     var browserDetails = utils.detectBrowser(window);
     // shim addTrack and removeTrack.
     if (window.RTCPeerConnection.prototype.addTrack &&
-        browserDetails.version >= 63) {
+        browserDetails.version >= 64) {
       return;
     }
 


### PR DESCRIPTION
Sorry this is a duplicate of #708, trying to reupload with email config updated.

In 63 (behind flag), addTrack etc. are supported, but it's not fully featured. By not shimming we get less things working and tests breaking.

Bumping to 64. May require bumping again in the future if Chrome is not ready to unflag for 64.