### PR TITLE
Bumped version number for shimAddTrackRemoveTrack

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -127,7 +127,7 @@ var chromeShim = {
             pc._senders.splice(idx, 1);
           }
         };
-      }a
+      }
       var origAddStream = window.RTCPeerConnection.prototype.addStream;
       window.RTCPeerConnection.prototype.addStream = function(stream) {
         var pc = this;

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -127,7 +127,7 @@ var chromeShim = {
             pc._senders.splice(idx, 1);
           }
         };
-      }
+      }a
       var origAddStream = window.RTCPeerConnection.prototype.addStream;
       window.RTCPeerConnection.prototype.addStream = function(stream) {
         var pc = this;

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -231,7 +231,7 @@ var chromeShim = {
     var browserDetails = utils.detectBrowser(window);
     // shim addTrack and removeTrack.
     if (window.RTCPeerConnection.prototype.addTrack &&
-        browserDetails.version >= 63) {
+        browserDetails.version >= 64) {
       return;
     }
 


### PR DESCRIPTION
In 63 (behind flag), addTrack etc. are supported, but it's not fully featured. By not shimming we get less things working and tests breaking.

Bumping to 64. May require bumping again in the future if Chrome is not ready to unflag for 64.

(Sorry for spam, this is a duplicate of #708 and #709, email should be fixed now... fingers crossed.)