### PR TITLE
test: update ontrack expectation in chrome-unstable

### DIFF
--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -46,7 +46,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
 PASS MSID signals track and stream ids
 PASS track event RTCPeerConnection.prototype.ontrack exists
-ERR track event is called when setRemoteDescription adds a new track to an existing stream timeout
+PASS track event is called when setRemoteDescription adds a new track to an existing stream
 PASS track event is called by setRemoteDescription track event
 PASS track event is called by setRemoteDescription ontrack
 PASS track event the event has a track


### PR DESCRIPTION
bug got fixed by hbos, update the expectation. Will need to be
trickled down to beta + stable as appropriate.