### PR TITLE
firefox: update test expectations to transceiver model

### DIFF
--- a/test/e2e/expectations/MicrosoftEdge
+++ b/test/e2e/expectations/MicrosoftEdge
@@ -56,13 +56,13 @@ ERR removeTrack allows removeTrack twice timeout
 ERR removeTrack throws an exception if the argument is a track, not a sender AssertionError
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError
 ERR removeTrack throws an exception if the peerconnection has been closed already AssertionError
-ERR removeTrack after addStream for an audio/video track after removing a single track only a single sender remains timeout
+ERR removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains timeout
 ERR removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched timeout
-ERR removeTrack after addStream for an audio/video track after removing all tracks no senders remain timeout
+ERR removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain timeout
 ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain timeout
-ERR removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains timeout
+ERR removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains timeout
 ERR removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched timeout
-ERR removeTrack after addTrack for an audio/video track after removing all tracks no senders remain timeout
+ERR removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain timeout
 ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain timeout
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCPeerConnection window.RTCPeerConnection exists

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 PASS navigator.mediaDevices enumerateDevices returns some audiooutput devices
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -1,8 +1,8 @@
 PASS addIceCandidate after setRemoteDescription resolves when called with null
 PASS addIceCandidate after setRemoteDescription resolves when called with undefined
-ERR addTrack throws an exception if the track has already been added AssertionError
-ERR addTrack throws an exception if the track has already been added via addStream AssertionError
-ERR addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
+PASS addTrack throws an exception if the track has already been added
+PASS addTrack throws an exception if the track has already been added via addStream
+PASS addTrack throws an exception if addStream is called with a stream containing a track already added
 PASS addTrack throws an exception if the peerconnection has been closed already
 PASS addTrack and getSenders creates a sender
 PASS addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added
@@ -70,7 +70,7 @@ PASS track event the event has a receiver that is contained in the set of receiv
 PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
-ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError
+PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
 PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -72,14 +72,14 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
-PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
+ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
+ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -1,8 +1,8 @@
 PASS addIceCandidate after setRemoteDescription resolves when called with null
 PASS addIceCandidate after setRemoteDescription resolves when called with undefined
-ERR addTrack throws an exception if the track has already been added AssertionError
-ERR addTrack throws an exception if the track has already been added via addStream AssertionError
-ERR addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
+PASS addTrack throws an exception if the track has already been added AssertionError
+PASS addTrack throws an exception if the track has already been added via addStream AssertionError
+PASS addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
 PASS addTrack throws an exception if the peerconnection has been closed already
 PASS addTrack and getSenders creates a sender
 PASS addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added
@@ -70,7 +70,7 @@ PASS track event the event has a receiver that is contained in the set of receiv
 PASS track event the event has a transceiver that has a receiver
 PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
-ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError
+PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
 PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -1,8 +1,8 @@
 PASS addIceCandidate after setRemoteDescription resolves when called with null
 PASS addIceCandidate after setRemoteDescription resolves when called with undefined
-PASS addTrack throws an exception if the track has already been added AssertionError
-PASS addTrack throws an exception if the track has already been added via addStream AssertionError
-PASS addTrack throws an exception if addStream is called with a stream containing a track already added AssertionError
+PASS addTrack throws an exception if the track has already been added
+PASS addTrack throws an exception if the track has already been added via addStream
+PASS addTrack throws an exception if addStream is called with a stream containing a track already added
 PASS addTrack throws an exception if the peerconnection has been closed already
 PASS addTrack and getSenders creates a sender
 PASS addTrack and getLocalStreams returns a stream with audio and video even if just an audio track was added
@@ -75,11 +75,11 @@ PASS removeTrack throws an exception if the peerconnection has been closed alrea
 PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
-PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
+ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
 PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
+ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 PASS removeTrack throws an exception if the sender does not belong to the peerconnection
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -40,13 +40,13 @@ PASS maxMessageSize sctp and maxMessageSize set if SCTP negotiated
 PASS maxMessageSize send largest possible single message
 PASS maxMessageSize throws an exception if the message is too large
 PASS maxMessageSize throws an exception if the message is too large (using a secondary data channel)
-PASS maxMessageSize is as expected for firefox==57 and chrome>=0 -> 65535
-PASS maxMessageSize is as expected for firefox==57 and firefox<=56 -> 65535
-PASS maxMessageSize is as expected for firefox==57 and firefox>=57 -> 65535
-PASS maxMessageSize is as expected for firefox==57 and 64 KiB -> 65535
-PASS maxMessageSize is as expected for firefox==57 and 1.5 GiB -> 65535
-PASS maxMessageSize is as expected for firefox==57 and 2 GiB -> 65535
-PASS maxMessageSize is as expected for firefox==57 and Unlimited -> 65535
+PASS maxMessageSize is as expected for firefox>=58 and chrome>=0 -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and firefox<=56 -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and firefox>=57 -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and 64 KiB -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and 1.5 GiB -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and 2 GiB -> 65536
+PASS maxMessageSize is as expected for firefox>=58 and Unlimited -> 65536
 PASS navigator.mediaDevices exists
 PASS navigator.mediaDevices is an EventTarget
 PASS navigator.mediaDevices implements the devicechange event

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -58,7 +58,7 @@ PASS navigator.mediaDevices enumerateDevices returns some audioinput devices
 PASS navigator.mediaDevices enumerateDevices returns some videoinput devices
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 PASS MediaStream window.MediaStream exists
-PASS MSID signals track and stream ids
+PASS MSID signals stream ids
 PASS MSID puts the track msid attribute into the localDescription
 PASS track event RTCPeerConnection.prototype.ontrack exists
 PASS track event is called when setRemoteDescription adds a new track to an existing stream

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -72,13 +72,13 @@ PASS removeTrack allows removeTrack twice
 PASS removeTrack throws an exception if the argument is a track, not a sender
 ERR removeTrack throws an exception if the sender does not belong to the peerconnection AssertionError
 PASS removeTrack throws an exception if the peerconnection has been closed already
-PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addStream for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addStream for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addStream for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addStream for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
-PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender remains
+PASS removeTrack after addTrack for an audio/video track after removing a single track only a single sender with a track remains
 PASS removeTrack after addTrack for an audio/video track after removing a single track the local stream remains untouched
-PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders remain
+PASS removeTrack after addTrack for an audio/video track after removing all tracks no senders with tracks remain
 PASS removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback

--- a/test/e2e/msid.js
+++ b/test/e2e/msid.js
@@ -40,9 +40,8 @@ describe('MSID', () => {
     pc2.close();
   });
 
-  it('signals track and stream ids', (done) => {
+  it('signals stream ids', (done) => {
     pc2.ontrack = (e) => {
-      expect(e.track.id).to.equal(localStream.getTracks()[0].id);
       expect(e.streams[0].id).to.equal(localStream.id);
       done();
     };

--- a/test/e2e/ontrack.js
+++ b/test/e2e/ontrack.js
@@ -111,8 +111,10 @@ describe('track event', () => {
       'a=rtpmap:100 vp8/90000\r\n' +
       'a=msid:stream1 track2\r\n' +
       'a=ssrc:1002 cname:some\r\n';
+    let ontrackCount = 0;
     pc.ontrack = (e) => {
-      if (e.track.id === 'track2') {
+      ontrackCount++;
+      if (ontrackCount === 2) {
         done();
       }
     };

--- a/test/e2e/removeTrack.js
+++ b/test/e2e/removeTrack.js
@@ -88,12 +88,13 @@ describe('removeTrack', () => {
       });
 
       describe('after removing a single track', () => {
-        it('only a single sender remains', () => {
+        it('only a single sender with a track remains', () => {
           const senders = pc.getSenders();
           expect(pc.getSenders()).to.have.length(2);
 
           pc.removeTrack(senders[0]);
-          expect(pc.getSenders()).to.have.length(1);
+          const sendersWithTrack = pc.getSenders().filter(s => s.track);
+          expect(sendersWithTrack).to.have.length(1);
         });
 
         it('the local stream remains untouched', () => {
@@ -106,10 +107,11 @@ describe('removeTrack', () => {
       });
 
       describe('after removing all tracks', () => {
-        it('no senders remain', () => {
+        it('no senders with tracks remain', () => {
           const senders = pc.getSenders();
           senders.forEach(sender => pc.removeTrack(sender));
-          expect(pc.getSenders()).to.have.length(0);
+          const sendersWithTrack = pc.getSenders().filter(s => s.track);
+          expect(sendersWithTrack).to.have.length(0);
         });
 
         it('no local streams remain', () => {


### PR DESCRIPTION
partial update of the firefox test expectations to better
reflect the FF59+ transceiver model

(still some test failures which might require test updates)