### PR TITLE
firefox: dont shim max-message-size when RTCPeerConnection is not defined

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -114,7 +114,7 @@ module.exports = {
   },
 
   shimMaxMessageSize: function(window) {
-    if (window.RTCSctpTransport) {
+    if (window.RTCSctpTransport || !window.RTCPeerConnection) {
       return;
     }
     var browserDetails = utils.detectBrowser(window);


### PR DESCRIPTION
fixes #757