### PR TITLE
allow SDP without ssrc to be processed correctly in Edge

### DIFF
--- a/release/adapter.js
+++ b/release/adapter.js
@@ -711,6 +711,8 @@ module.exports = function(window, edgeVersion) {
       if (transceiver.recvEncodingParameters.length) {
         params.encodings = transceiver.recvEncodingParameters;
       }
+      else
+        params.encodings = [{}];
       params.rtcp = {
         compound: transceiver.rtcpParameters.compound
       };

--- a/release/adapter_no_global.js
+++ b/release/adapter_no_global.js
@@ -711,6 +711,8 @@ module.exports = function(window, edgeVersion) {
       if (transceiver.recvEncodingParameters.length) {
         params.encodings = transceiver.recvEncodingParameters;
       }
+      else
+        params.encodings = [{}];
       params.rtcp = {
         compound: transceiver.rtcpParameters.compound
       };


### PR DESCRIPTION
**Description**
My server provides SDP without ssrc and it's absolutely allowed by RFC.
In this case in Edge params.encodings for receive(params) function will not be set. 
This causes InvalidAccessError exception to be thrown. 

Though if you supply even empty encoding like this [{}] it will make receive work and identify media by port. According to [specification](https://msdn.microsoft.com/en-us/library/mt599600(v=vs.85).aspx) it will default to 
```
{
    ssrc: null,
    active: true
}

```
**Purpose**
To be able to use simpler SDP without specifying ssrc.
