### PR TITLE
all: do not throw on empty candidate

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -29,23 +29,27 @@ module.exports = {
         args.candidate = args.candidate.substr(2);
       }
 
-      // Augment the native candidate with the parsed fields.
-      var nativeCandidate = new NativeRTCIceCandidate(args);
-      var parsedCandidate = SDPUtils.parseCandidate(args.candidate);
-      var augmentedCandidate = Object.assign(nativeCandidate,
-          parsedCandidate);
+      if (args.candidate && args.candidate.length) {
+        // Augment the native candidate with the parsed fields.
+        var nativeCandidate = new NativeRTCIceCandidate(args);
+        var parsedCandidate = SDPUtils.parseCandidate(args.candidate);
+        var augmentedCandidate = Object.assign(nativeCandidate,
+            parsedCandidate);
 
-      // Add a serializer that does not serialize the extra attributes.
-      augmentedCandidate.toJSON = function() {
-        return {
-          candidate: augmentedCandidate.candidate,
-          sdpMid: augmentedCandidate.sdpMid,
-          sdpMLineIndex: augmentedCandidate.sdpMLineIndex,
-          usernameFragment: augmentedCandidate.usernameFragment,
+        // Add a serializer that does not serialize the extra attributes.
+        augmentedCandidate.toJSON = function() {
+          return {
+            candidate: augmentedCandidate.candidate,
+            sdpMid: augmentedCandidate.sdpMid,
+            sdpMLineIndex: augmentedCandidate.sdpMLineIndex,
+            usernameFragment: augmentedCandidate.usernameFragment,
+          };
         };
-      };
-      return augmentedCandidate;
+        return augmentedCandidate;
+      }
+      return new NativeRTCIceCandidate(args);
     };
+    window.RTCIceCandidate.prototype = NativeRTCIceCandidate.prototype;
 
     // Hook up the augmented candidate in onicecandidate and
     // addEventListener('icecandidate', ...)

--- a/test/e2e/expectations/Electron
+++ b/test/e2e/expectations/Electron
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/chrome-stable
+++ b/test/e2e/expectations/chrome-stable
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/chrome-stable-no-experimental
+++ b/test/e2e/expectations/chrome-stable-no-experimental
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -83,6 +83,7 @@ ERR removeTrack after addTrack for an audio/video track after removing all track
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+PASS RTCIceCandidate with empty candidate.candidate does not throw
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+PASS RTCIceCandidate with empty candidate.candidate does not throw
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -83,6 +83,7 @@ ERR removeTrack after addTrack for an audio/video track after removing all track
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+PASS RTCIceCandidate with empty candidate.candidate does not throw
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -83,6 +83,7 @@ PASS removeTrack after addTrack for an audio/video track after removing all trac
 PASS RTCIceCandidate window.RTCIceCandidate exists
 PASS RTCIceCandidate is augmented in the onicecandidate callback
 PASS RTCIceCandidate is augmented in the icecandidate event
+PASS RTCIceCandidate with empty candidate.candidate does not throw
 PASS RTCIceCandidate icecandidate eventlistener can be removed
 PASS RTCPeerConnection window.RTCPeerConnection exists
 PASS RTCPeerConnection constructor works

--- a/test/e2e/rtcicecandidate.js
+++ b/test/e2e/rtcicecandidate.js
@@ -45,6 +45,15 @@ describe('RTCIceCandidate', () => {
     });
   });
 
+  describe('with empty candidate.candidate', () => {
+    it('does not throw', () => {
+      const constructor = () => {
+        return new RTCIceCandidate({sdpMid: 'foo', candidate: ''});
+      };
+      expect(constructor).not.to.throw();
+    });
+  });
+
   describe('icecandidate eventlistener', () => {
     it('can be removed', () => {
       let wrongCalled = false;


### PR DESCRIPTION
(or let the native browser throw up)

Chrome actually throws so marked as expected failure.