### PR TITLE
Stop shimSendThrowTypeError from throwing error in Firefox with peerConnection disabled

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -245,6 +245,10 @@ module.exports = {
   },
 
   shimSendThrowTypeError: function(window) {
+    if (!window.RTCPeerConnection) {
+      return;
+    }
+
     // Note: Although Firefox >= 57 has a native implementation, the maximum
     //       message size can be reset for all data channels at a later stage.
     //       See: https://bugzilla.mozilla.org/show_bug.cgi?id=1426831


### PR DESCRIPTION
**Description**
Related to https://github.com/webrtc/adapter/issues/757. When using version 6.1.1 of this library in Firefox with `media.peerconnection.enabled.` set to false, it will throw an error at shimSendThrowTypeError.

**Purpose**
This fixes the library in Firefox.