### PR TITLE
chrome: override legacy createDTMFSender

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -188,6 +188,25 @@ module.exports = {
           return this._dtmf;
         }
       });
+    } else if (typeof window === 'object' && window.RTCPeerConnection &&
+        ('getSenders' in window.RTCPeerConnection.prototype) &&
+        (window.RTCRtpSender && 'dtmf' in window.RTCRtpSender.prototype)) {
+      // override legacy createDTMFSender.
+      window.RTCPeerConnection.prototype.createDTMFSender = function(track) {
+        if (track.kind !== 'audio') {
+          throw new DOMException('Track is not an audio track.',
+              'TypeError');
+        }
+        utils.deprecated('RTCPeerConnection.createDTMFSender',
+            'RTCRtpSender.dtmf');
+        var sender = this.getSenders().find(function(s) {
+          return s.track === track;
+        });
+        if (sender) {
+          return sender.dtmf;
+        }
+        // TODO: figure out an error for track not being found.
+      };
     }
   },
 


### PR DESCRIPTION
@alvestrand @foolip PTAL. Not sure this is a good idea but... ;-)

Still undecided on the error to throw when there is no sender for the track. Chrome seems to throw a SyntaxError or a NotSupportedError (the latter for adding video tracks?!)