### PR TITLE
Chrome unstable: addTrack works with DTMF, update expectations

### DIFF
--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -28,7 +28,7 @@ PASS URL.createObjectURL shim works for video using setAttribute
 PASS dtmf RTCRtpSender.dtmf exists on audio senders
 PASS dtmf RTCRtpSender.dtmf does not exist on video senders
 PASS dtmf inserts DTMF when using addStream
-ERR dtmf inserts DTMF when using addTrack timeout
+PASS dtmf inserts DTMF when using addTrack
 PASS getStats returns a Promise
 PASS getStats resolves the Promise with a Map(like)
 PASS getUserMedia navigator.getUserMedia exists


### PR DESCRIPTION
Chrome has now been fixed, expectations updated accordingly on unstable. See #733