### PR TITLE
Adding adapter support for iOS WKWebView

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -159,14 +159,8 @@ module.exports = {
       result.browser = 'edge';
       result.version = extractVersion(navigator.userAgent,
           /Edge\/(\d+).(\d+)$/, 2);
-    } else if (navigator.mediaDevices &&
+    } else if (window.RTCPeerConnection &&
         navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) { // Safari.
-      result.browser = 'safari';
-      result.version = extractVersion(navigator.userAgent,
-          /AppleWebKit\/(\d+)\./, 1);
-    } else if (navigator.userAgent.match(/AppleWebKit\/(\d+)\./) &&
-        (navigator.userAgent.match(/iPhone|iPad/))) {
-      // WKWebView on iOS; Where mediaDevices is still unsupported
       result.browser = 'safari';
       result.version = extractVersion(navigator.userAgent,
           /AppleWebKit\/(\d+)\./, 1);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -165,11 +165,11 @@ module.exports = {
       result.version = extractVersion(navigator.userAgent,
           /AppleWebKit\/(\d+)\./, 1);
     } else if (navigator.userAgent.match(/AppleWebKit\/(\d+)\./) &&
-        (navigator.platform === 'iPhone' || navigator.platfrm === 'iPad')) { 
-          // WKWebView on iOS; Where mediaDevices is still unsupported
-          result.browser = 'safari';
-          result.version = extractVersion(navigator.userAgent,
-        /AppleWebKit\/(\d+)\./, 1);
+        (navigator.userAgent.match(/iPhone|iPad/))) {
+      // WKWebView on iOS; Where mediaDevices is still unsupported
+      result.browser = 'safari';
+      result.version = extractVersion(navigator.userAgent,
+          /AppleWebKit\/(\d+)\./, 1);
     } else { // Default fallthrough: not supported.
       result.browser = 'Not a supported browser.';
       return result;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -164,6 +164,12 @@ module.exports = {
       result.browser = 'safari';
       result.version = extractVersion(navigator.userAgent,
           /AppleWebKit\/(\d+)\./, 1);
+    } else if (navigator.userAgent.match(/AppleWebKit\/(\d+)\./) &&
+        (navigator.platform === 'iPhone' || navigator.platfrm === 'iPad')) { 
+          // WKWebView on iOS; Where mediaDevices is still unsupported
+          result.browser = 'safari';
+          result.version = extractVersion(navigator.userAgent,
+        /AppleWebKit\/(\d+)\./, 1);
     } else { // Default fallthrough: not supported.
       result.browser = 'Not a supported browser.';
       return result;

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -52,21 +52,10 @@ describe('detectBrowser', () => {
     expect(browserDetails.version).to.equal(10547);
   });
 
-  it('detects Safari if navigator.mediaDevices exists', () => {
+  it('detects Safari if window.RTCPeerConnection exists', () => {
     navigator.userAgent = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
-    navigator.mediaDevices = function() {};
-
-    const browserDetails = detectBrowser(window);
-    expect(browserDetails.browser).to.equal('safari');
-    expect(browserDetails.version).to.equal(604);
-  });
-
-  it('detects iOSWKWebView if navigator.mediaDevices doens\'t exist', () => {
-    navigator.userAgent = 'Mozilla/5.0 ' +
-        '(iPhone; CPU iPhone OS 11_2 like Mac OS X) ' +
-        'AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C107';
-    navigator.mediaDevices = undefined;
+    window.RTCPeerConnection = function() {};
 
     const browserDetails = detectBrowser(window);
     expect(browserDetails.browser).to.equal('safari');

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -61,4 +61,15 @@ describe('detectBrowser', () => {
     expect(browserDetails.browser).to.equal('safari');
     expect(browserDetails.version).to.equal(604);
   });
+
+  it('detects iOSWKWebView if navigator.mediaDevices doens\'t exist', () => {
+    navigator.userAgent = 'Mozilla/5.0 ' +
+        '(iPhone; CPU iPhone OS 11_2 like Mac OS X) ' +
+        'AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C107';
+    navigator.mediaDevices = undefined;
+
+    const browserDetails = detectBrowser(window);
+    expect(browserDetails.browser).to.equal('safari');
+    expect(browserDetails.version).to.equal(604);
+  });
 });


### PR DESCRIPTION
**Description**
When using adapter.js inside an iOS In-App Browser (WKWebView) - adpater classifies it as a "unsupported browser" even though most of the WebRTC APIs **are** supported. 
"detect_browser" checks only for `getUserMedia()` which is exactly the API that is not supported.

This fix adds Web Views on iPhone & iPad as a `safari` supported browser

**Purpose**
Despite the fact that getUserMedia() is still not supported on this Web View version of Safari on iOS,
adapter.js can and does help with the other APIs when running on WKWebView and I see no reason supporting it. 
I used adapter.js myself for some RTCPeerConnection shim work inside the Web View, 
but only after I added it as a supported browser.

Offering back this fix to the community. 
Added a Unit Test too.

see issue #784 