### PR TITLE
edge: add RTCDTMFSender alias

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -60,6 +60,11 @@ module.exports = {
         }
       });
     }
+    // Edge currently only implements the RTCDtmfSender, not the
+    // RTCDTMFSender alias. See http://draft.ortc.org/#rtcdtmfsender2*
+    if (window.RTCDtmfSender && !window.RTCDTMFSender) {
+      window.RTCDTMFSender = window.RTCDtmfSender;
+    }
 
     window.RTCPeerConnection =
         shimRTCPeerConnection(window, browserDetails.version);


### PR DESCRIPTION
**Description**
adds RTCDTMFSender if it does not exist. Its a simple alias to
RTCDtmfSender as described in http://draft.ortc.org/#rtcdtmfsender2*

**Purpose**
Less things to worry about ;-)