### PR TITLE
common: check RTCIceCandidate exists before trying to shim

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -15,8 +15,8 @@ module.exports = {
   shimRTCIceCandidate: function(window) {
     // foundation is arbitrarily chosen as an indicator for full support for
     // https://w3c.github.io/webrtc-pc/#rtcicecandidate-interface
-    if (window.RTCIceCandidate && 'foundation' in
-        window.RTCIceCandidate.prototype) {
+    if (!window.RTCIceCandidate || (window.RTCIceCandidate && 'foundation' in
+        window.RTCIceCandidate.prototype)) {
       return;
     }
 

--- a/test/unit/adapter_factory.js
+++ b/test/unit/adapter_factory.js
@@ -37,4 +37,14 @@ describe('adapter factory', () => {
       expect(adapter).not.to.have.property('browserShim');
     });
   });
+
+  describe('Firefox with peerconnection disabled', () => {
+    window = {navigator: {
+      mozGetUserMedia: () => {},
+      userAgent: 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:44.0) ' +
+          'Gecko/20100101 Firefox/44.0'
+    }};
+    const constructor = () => adapterFactory({window});
+    expect(constructor).not.to.throw();
+  });
 });


### PR DESCRIPTION
fixes an exception in firefox with peerconnection disabled

Also adds a very, very basic unit test to detect issues like this in the future.