### PR TITLE
edge: move filterIceServers back to adapter

### DIFF
--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -9,6 +9,7 @@
 'use strict';
 
 var utils = require('../utils');
+var filterIceServers = require('./filtericeservers');
 var shimRTCPeerConnection = require('rtcpeerconnection-shim');
 
 module.exports = {
@@ -66,8 +67,15 @@ module.exports = {
       window.RTCDTMFSender = window.RTCDtmfSender;
     }
 
-    window.RTCPeerConnection =
-        shimRTCPeerConnection(window, browserDetails.version);
+    var RTCPeerConnectionShim = shimRTCPeerConnection(window,
+        browserDetails.version);
+    window.RTCPeerConnection = function(config) {
+      if (config.iceServers) {
+        config.iceServers = filterIceServers(config.iceServers);
+      }
+      return new RTCPeerConnectionShim(config);
+    };
+    window.RTCPeerConnection.prototype = RTCPeerConnectionShim.prototype;
   },
   shimReplaceTrack: function(window) {
     // ORTC has replaceTrack -- https://github.com/w3c/ortc/issues/614

--- a/src/js/edge/filtericeservers.js
+++ b/src/js/edge/filtericeservers.js
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2018 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+var utils = require('../utils');
+// Edge does not like
+// 1) stun: filtered after 14393 unless ?transport=udp is present
+// 2) turn: that does not have all of turn:host:port?transport=udp
+// 3) turn: with ipv6 addresses
+// 4) turn: occurring muliple times
+module.exports = function(iceServers, edgeVersion) {
+  var hasTurn = false;
+  iceServers = JSON.parse(JSON.stringify(iceServers));
+  return iceServers.filter(function(server) {
+    if (server && (server.urls || server.url)) {
+      var urls = server.urls || server.url;
+      if (server.url && !server.urls) {
+        utils.deprecated('RTCIceServer.url', 'RTCIceServer.urls');
+      }
+      var isString = typeof urls === 'string';
+      if (isString) {
+        urls = [urls];
+      }
+      urls = urls.filter(function(url) {
+        var validTurn = url.indexOf('turn:') === 0 &&
+            url.indexOf('transport=udp') !== -1 &&
+            url.indexOf('turn:[') === -1 &&
+            !hasTurn;
+
+        if (validTurn) {
+          hasTurn = true;
+          return true;
+        }
+        return url.indexOf('stun:') === 0 && edgeVersion >= 14393 &&
+            url.indexOf('?transport=udp') === -1;
+      });
+
+      delete server.url;
+      server.urls = isString ? urls[0] : urls;
+      return !!urls.length;
+    }
+  });
+};

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -38,4 +38,84 @@ describe('Edge shim', () => {
     shim.shimPeerConnection(window);
     expect(window.RTCPeerConnection).not.to.equal(true);
   });
+
+  describe('filtering of STUN and TURN servers', () => {
+    const edgeVersion = 15025;
+    const filterIceServers = require('../../src/js/edge/filtericeservers');
+
+    it('converts legacy url member to urls', () => {
+      const result = filterIceServers([
+        {url: 'stun:stun.l.google.com'}
+      ], edgeVersion);
+      expect(result).to.deep.equal([
+        {urls: 'stun:stun.l.google.com'}
+      ]);
+    });
+
+    it('filters STUN before r14393', () => {
+      const result = filterIceServers([
+        {urls: 'stun:stun.l.google.com'}
+      ], 14392);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('does not filter STUN without protocol after r14393', () => {
+      const result = filterIceServers([
+        {urls: 'stun:stun.l.google.com'}
+      ], edgeVersion);
+      expect(result).to.deep.equal([
+        {urls: 'stun:stun.l.google.com'}
+      ]);
+    });
+
+    it('does filter STUN with protocol even after r14393', () => {
+      const result = filterIceServers([
+        {urls: 'stun:stun.l.google.com:19302?transport=udp'}
+      ], edgeVersion);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('filters incomplete TURN urls', () => {
+      const result = filterIceServers([
+        {urls: 'turn:stun.l.google.com'},
+        {urls: 'turn:stun.l.google.com:19302'}
+      ], edgeVersion);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('filters TURN TCP', () => {
+      const result = filterIceServers([
+        {urls: 'turn:stun.l.google.com:19302?transport=tcp'}
+      ], edgeVersion);
+      expect(result).to.deep.equal([]);
+    });
+
+    describe('removes all but the first server of a type', () => {
+      it('in separate entries', () => {
+        const result = filterIceServers([
+          {urls: 'stun:stun.l.google.com'},
+          {urls: 'turn:stun.l.google.com:19301?transport=udp'},
+          {urls: 'turn:stun.l.google.com:19302?transport=udp'}
+        ], edgeVersion);
+        expect(result).to.deep.equal([
+          {urls: 'stun:stun.l.google.com'},
+          {urls: 'turn:stun.l.google.com:19301?transport=udp'}
+        ]);
+      });
+
+      it('in urls entries', () => {
+        const result = filterIceServers([
+          {urls: 'stun:stun.l.google.com'},
+          {urls: [
+            'turn:stun.l.google.com:19301?transport=udp',
+            'turn:stun.l.google.com:19302?transport=udp'
+          ]}
+        ], edgeVersion);
+        expect(result).to.deep.equal([
+          {urls: 'stun:stun.l.google.com'},
+          {urls: ['turn:stun.l.google.com:19301?transport=udp']}
+        ]);
+      });
+    });
+  });
 });


### PR DESCRIPTION
moves filterIceServers back to adapter.js from
  https://github.com/otalk/rtcpeerconnection-shim

This is an edge-specific workaround and I'd prefer it in adapter following the "all the ugly workarounds belong here" rationale