### PR TITLE
common: dont override createDataChannel if it does not exist

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -249,7 +249,8 @@ module.exports = {
   },
 
   shimSendThrowTypeError: function(window) {
-    if (!window.RTCPeerConnection) {
+    if (!(window.RTCPeerConnection &&
+        'createDataChannel' in window.RTCPeerConnection.prototype)) {
       return;
     }
 


### PR DESCRIPTION
fixes #799 

cc @lgrahl 