### PR TITLE
common utils: Update chrome feature detection

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -148,7 +148,8 @@ module.exports = {
       result.browser = 'firefox';
       result.version = extractVersion(navigator.userAgent,
           /Firefox\/(\d+)\./, 1);
-    } else if (navigator.webkitGetUserMedia) {
+    } else if (navigator.webkitGetUserMedia || 
+      window.chrome.webstore) {
       // Chrome, Chromium, Webview, Opera.
       // Version matches Chrome/WebRTC version.
       result.browser = 'chrome';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -149,7 +149,7 @@ module.exports = {
       result.version = extractVersion(navigator.userAgent,
           /Firefox\/(\d+)\./, 1);
     } else if (navigator.webkitGetUserMedia || 
-      window.chrome.webstore) {
+        window.chrome.webstore) {
       // Chrome, Chromium, Webview, Opera.
       // Version matches Chrome/WebRTC version.
       result.browser = 'chrome';

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -41,6 +41,17 @@ describe('detectBrowser', () => {
     expect(browserDetails.version).to.equal(45);
   });
 
+  it('detects Chrome if window.chrome.webstore exists', () => {
+    navigator.userAgent = 'Mozilla/5.0 (X11; Linux x86_64) ' +
+        'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 ' +
+        'Safari/537.36';
+    window.chrome.webstore = function() {};
+
+    const browserDetails = detectBrowser(window);
+    expect(browserDetails.browser).to.equal('chrome');
+    expect(browserDetails.version).to.equal(45);
+  });
+
   it('detects Edge if navigator.mediaDevices exists', () => {
     navigator.userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
         'AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 ' +


### PR DESCRIPTION
**Description**
This PR adds an additional feature detection check to ensure correctly detecting Chrome browsers using `window.chrome.webstore`.

**Purpose**
`navigator.webketGetUserMedia` will be removed from Google Chrome, and the desktop version of the browser will not be correctly detected by the `utils.detectBrowser()` method. This is documented in this issue here: https://github.com/webrtc/adapter/issues/764. This change will replace it with a check for `window.chrome.webstore`, which is unique to the Chrome browser.

*Note: this will not detect Chrome for iOS, which is not a full version of the browser.*