### PR TITLE
package: remove tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "mocha": "^3.2.0",
     "sinon": "^2.2.0",
     "sinon-chai": "^2.14.0",
-    "tape": "^4.9.0",
     "travis-multirunner": "^4.4.0"
   }
 }


### PR DESCRIPTION
removes tape from devDependencies. Tests have not used tape
for a while