### PR TITLE
support maxMessageSize in datachannel.send on receive side too

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -261,16 +261,9 @@ module.exports = {
     //       message size can be reset for all data channels at a later stage.
     //       See: https://bugzilla.mozilla.org/show_bug.cgi?id=1426831
 
-    var origCreateDataChannel =
-      window.RTCPeerConnection.prototype.createDataChannel;
-    window.RTCPeerConnection.prototype.createDataChannel = function() {
-      var pc = this;
-      var dataChannel = origCreateDataChannel.apply(pc, arguments);
-      var origDataChannelSend = dataChannel.send;
-
-      // Patch 'send' method
-      dataChannel.send = function() {
-        var dc = this;
+    function wrapDcSend(dc, pc) {
+      var origDataChannelSend = dc.send;
+      dc.send = function() {
         var data = arguments[0];
         var length = data.length || data.size || data.byteLength;
         if (length > pc.sctp.maxMessageSize) {
@@ -279,8 +272,18 @@ module.exports = {
         }
         return origDataChannelSend.apply(dc, arguments);
       };
-
+    }
+    var origCreateDataChannel =
+      window.RTCPeerConnection.prototype.createDataChannel;
+    window.RTCPeerConnection.prototype.createDataChannel = function() {
+      var pc = this;
+      var dataChannel = origCreateDataChannel.apply(pc, arguments);
+      wrapDcSend(dataChannel, pc);
       return dataChannel;
     };
+    utils.wrapPeerConnectionEvent(window, 'datachannel', function(e) {
+      wrapDcSend(e.channel, e.target);
+      return e;
+    });
   }
 };

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -266,9 +266,10 @@ module.exports = {
       dc.send = function() {
         var data = arguments[0];
         var length = data.length || data.size || data.byteLength;
-        if (length > pc.sctp.maxMessageSize) {
-          throw new DOMException('Message too large (can send a maximum of ' +
-            pc.sctp.maxMessageSize + ' bytes)', 'TypeError');
+        if (dc.readyState === 'open' &&
+            pc.sctp && length > pc.sctp.maxMessageSize) {
+          throw new TypeError('Message too large (can send a maximum of ' +
+            pc.sctp.maxMessageSize + ' bytes)');
         }
         return origDataChannelSend.apply(dc, arguments);
       };


### PR DESCRIPTION
wraps dc.send also on the receiver side in the ondatachannel event
in addition to the createDataChannel method.