### PR TITLE
firefox: shim RTCDataChannel

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -97,6 +97,7 @@ module.exports = function(dependencies, opts) {
       firefoxShim.shimRemoveStream(window);
       firefoxShim.shimSenderGetStats(window);
       firefoxShim.shimReceiverGetStats(window);
+      firefoxShim.shimRTCDataChannel(window);
 
       commonShim.shimRTCIceCandidate(window);
       commonShim.shimMaxMessageSize(window);

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -275,5 +275,13 @@ module.exports = {
         }
       });
     };
-  }
+  },
+
+  shimRTCDataChannel: function(window) {
+    // rename DataChannel to RTCDataChannel (native fix in FF60):
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1173851
+    if (window.DataChannel && !window.RTCDataChannel) {
+      window.RTCDataChannel = window.DataChannel;
+    }
+  },
 };


### PR DESCRIPTION
which used to exist as window.DataChannel. See
  https://bugzilla.mozilla.org/show_bug.cgi?id=1173851

@nils-ohlmeier can you please take a look?