### PR TITLE
chrome: shim RTCPeerConnection.getStats(track)

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -73,8 +73,7 @@ module.exports = function(dependencies, opts) {
       chromeShim.shimOnTrack(window);
       chromeShim.shimAddTrackRemoveTrack(window);
       chromeShim.shimGetSendersWithDtmf(window);
-      chromeShim.shimSenderGetStats(window);
-      chromeShim.shimReceiverGetStats(window);
+      chromeShim.shimSenderReceiverGetStats(window);
 
       commonShim.shimRTCIceCandidate(window);
       commonShim.shimMaxMessageSize(window);


### PR DESCRIPTION
using sender/receiver stats

after this RTCPeerConnection-track-stats.https.html only fails in
* replaceTrack(): original track attachment stats present after replacing
* RTCPeerConnection.getStats(track) throws InvalidAccessError when there are multiple senders for the track

(at some point i want WPT to run here...)
