### PR TITLE
chrome: only shim error codes in Chrome < 64

### DIFF
--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -133,6 +133,9 @@ module.exports = function(window) {
   };
 
   var shimError_ = function(e) {
+    if (browserDetails.version >= 64) {
+      return e;
+    }
     return {
       name: {
         PermissionDeniedError: 'NotAllowedError',


### PR DESCRIPTION
(see discussion in #835)
Error names were fixed in M64, see https://groups.google.com/forum/#!msg/discuss-webrtc/fIWg5n67xHo/QIhRnv6vBgAJ
Not using the code in new versions means we have less code in the path and a smaller chance of introducing issues like #835