### PR TITLE
firefox_shim: make ontrack shim configurable

### DIFF
--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -35,7 +35,9 @@ module.exports = {
               this.dispatchEvent(event);
             }.bind(this));
           }.bind(this));
-        }
+        },
+        enumerable: true,
+        configurable: true
       });
     }
     if (typeof window === 'object' && window.RTCTrackEvent &&


### PR DESCRIPTION
If you include adapter-latest.js (v6.3.0) in a web page, old versions of Firefox (in my case 43.0.1) will throw the following:
> TypeError: can't redefine non-configurable property "ontrack"

This issue is similar to #832 (fixed by #833). Except that this one occurs even if you include the adapter only once.
