### PR TITLE
safari: fix createOffer callbacks API

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -134,12 +134,12 @@ module.exports = function(dependencies, opts) {
       commonShim.shimCreateObjectURL(window);
 
       safariShim.shimRTCIceServerUrls(window);
+      safariShim.shimCreateOfferLegacy(window);
       safariShim.shimCallbacksAPI(window);
       safariShim.shimLocalStreamsAPI(window);
       safariShim.shimRemoteStreamsAPI(window);
       safariShim.shimTrackEventTransceiver(window);
       safariShim.shimGetUserMedia(window);
-      safariShim.shimCreateOfferLegacy(window);
 
       commonShim.shimRTCIceCandidate(window);
       commonShim.shimMaxMessageSize(window);


### PR DESCRIPTION
This change fixes a bug where the legacy callbacks API for Safari
createOffer didn't return as expected when compared to the currently
working promises API.

This was due to the order of shims in adapter_factory, where the
shimCreateOfferLegacy which does trasceiver stuff and overwrites the
createOffer prototype was called after shimCallbacksAPI already fixed
the createOffer function to support callbacks.

Moreover, this happened only because the order of arguments to
createOffer int he first place, where the callbacks come first (wtf)
before the options, meaning that the options argument changes order
between the callback and promise API. If only we could go back in
time...

Fixes #859

**Description**


**Purpose**
