### PR TITLE
chrome: support width/height in getDisplayMedia

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -741,6 +741,8 @@ export function shimGetDisplayMedia(window, getSourceId) {
           mandatory: {
             chromeMediaSource: 'desktop',
             chromeMediaSourceId: sourceId,
+            maxWidth: constraints.video.width,
+            maxHeight: constraints.video.height,
             maxFrameRate: constraints.video.frameRate || 3
           }
         };


### PR DESCRIPTION
using a very simple shim

needs to be backported to 6.1.4 branch