### PR TITLE
shim navigator.mediaDevices.getDisplayMedia

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -90,6 +90,7 @@ export function adapterFactory({window} = {}, options = {
       adapter.browserShim = edgeShim;
 
       edgeShim.shimGetUserMedia(window);
+      edgeShim.shimGetDisplayMedia(window);
       edgeShim.shimPeerConnection(window);
       edgeShim.shimReplaceTrack(window);
 

--- a/src/js/chrome/getdisplaymedia.js
+++ b/src/js/chrome/getdisplaymedia.js
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2018 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+'use strict';
+export function shimGetDisplayMedia(window, getSourceId) {
+  if (window.navigator.mediaDevices &&
+    'getDisplayMedia' in window.navigator.mediaDevices) {
+    return;
+  }
+  if (!(window.navigator.mediaDevices)) {
+    return;
+  }
+  // getSourceId is a function that returns a promise resolving with
+  // the sourceId of the screen/window/tab to be shared.
+  if (typeof getSourceId !== 'function') {
+    console.error('shimGetDisplayMedia: getSourceId argument is not ' +
+        'a function');
+    return;
+  }
+  window.navigator.mediaDevices.getDisplayMedia = function(constraints) {
+    return getSourceId(constraints)
+      .then(sourceId => {
+        const widthSpecified = constraints.video && constraints.video.width;
+        const heightSpecified = constraints.video && constraints.video.height;
+        const frameRateSpecified = constraints.video &&
+          constraints.video.frameRate;
+        constraints.video = {
+          mandatory: {
+            chromeMediaSource: 'desktop',
+            chromeMediaSourceId: sourceId,
+            maxFrameRate: frameRateSpecified || 3
+          }
+        };
+        if (widthSpecified) {
+          constraints.video.mandatory.maxWidth = widthSpecified;
+        }
+        if (heightSpecified) {
+          constraints.video.mandatory.maxHeight = heightSpecified;
+        }
+        return window.navigator.mediaDevices.getUserMedia(constraints);
+      });
+  };
+}

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -13,6 +13,7 @@ import {filterIceServers} from './filtericeservers';
 import shimRTCPeerConnection from 'rtcpeerconnection-shim';
 
 export {shimGetUserMedia} from './getusermedia';
+export {shimGetDisplayMedia} from './getdisplaymedia';
 
 export function shimPeerConnection(window) {
   const browserDetails = utils.detectBrowser(window);

--- a/src/js/edge/getdisplaymedia.js
+++ b/src/js/edge/getdisplaymedia.js
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2018 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+export function shimGetDisplayMedia(window) {
+  if (!('getDisplayMedia' in window.navigator)) {
+    return;
+  }
+  if (!(window.navigator.mediaDevices)) {
+    return;
+  }
+  if (window.navigator.mediaDevices &&
+    'getDisplayMedia' in window.navigator.mediaDevices) {
+    return;
+  }
+  window.navigator.mediaDevices.getDisplayMedia =
+    window.navigator.getDisplayMedia.bind(window.navigator.mediaDevices);
+}

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -10,6 +10,7 @@
 
 import * as utils from '../utils';
 export {shimGetUserMedia} from './getusermedia';
+export {shimGetDisplayMedia} from './getdisplaymedia';
 
 export function shimOnTrack(window) {
   if (typeof window === 'object' && window.RTCTrackEvent &&
@@ -154,28 +155,6 @@ export function shimReceiverGetStats(window) {
   });
   window.RTCRtpReceiver.prototype.getStats = function() {
     return this._pc.getStats(this.track);
-  };
-}
-
-export function shimGetDisplayMedia(window, preferredMediaSource) {
-  if ('getDisplayMedia' in window.navigator) {
-    return;
-  }
-  navigator.getDisplayMedia = function(constraints) {
-    if (!(constraints && constraints.video)) {
-      const err = new DOMException('getDisplayMedia without video ' +
-          'constraints is undefined');
-      err.name = 'NotFoundError';
-      // from https://heycam.github.io/webidl/#idl-DOMException-error-names
-      err.code = 8;
-      return Promise.reject(err);
-    }
-    if (constraints.video === true) {
-      constraints.video = {mediaSource: preferredMediaSource};
-    } else {
-      constraints.video.mediaSource = preferredMediaSource;
-    }
-    return navigator.mediaDevices.getUserMedia(constraints);
   };
 }
 

--- a/src/js/firefox/getdisplaymedia.js
+++ b/src/js/firefox/getdisplaymedia.js
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2018 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+'use strict';
+
+export function shimGetDisplayMedia(window, preferredMediaSource) {
+  if (window.navigator.mediaDevices &&
+    'getDisplayMedia' in window.navigator.mediaDevices) {
+    return;
+  }
+  if (!(window.navigator.mediaDevices)) {
+    return;
+  }
+  window.navigator.mediaDevices.getDisplayMedia = function(constraints) {
+    if (!(constraints && constraints.video)) {
+      const err = new DOMException('getDisplayMedia without video ' +
+          'constraints is undefined');
+      err.name = 'NotFoundError';
+      // from https://heycam.github.io/webidl/#idl-DOMException-error-names
+      err.code = 8;
+      return Promise.reject(err);
+    }
+    if (constraints.video === true) {
+      constraints.video = {mediaSource: preferredMediaSource};
+    } else {
+      constraints.video.mediaSource = preferredMediaSource;
+    }
+    return window.navigator.mediaDevices.getUserMedia(constraints);
+  };
+}

--- a/test/unit/firefox.js
+++ b/test/unit/firefox.js
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+chai.use(sinonChai);
+
+describe('Firefox shim', () => {
+  const shim = require('../../dist/firefox/firefox_shim');
+  let window;
+
+  beforeEach(() => {
+    window = {
+      navigator: {
+        mediaDevices: {
+          getUserMedia: sinon.stub(),
+        },
+      },
+    };
+  });
+
+  describe('getDisplayMedia shim', () => {
+    it('does not if navigator.mediaDevices does not exist', () => {
+      delete window.navigator.mediaDevices;
+      shim.shimGetDisplayMedia(window);
+      expect(window.navigator.mediaDevices).to.equal(undefined);
+    });
+
+    it('does not overwrite an existing ' +
+        'navigator.mediaDevices.getDisplayMedia', () => {
+      window.navigator.mediaDevices.getDisplayMedia = 'foo';
+      shim.shimGetDisplayMedia(window, 'screen');
+      expect(window.navigator.mediaDevices.getDisplayMedia).to.equal('foo');
+    });
+
+    it('shims navigator.mediaDevices.getDisplayMedia', () => {
+      shim.shimGetDisplayMedia(window, 'screen');
+      expect(window.navigator.mediaDevices.getDisplayMedia).to.be.a('function');
+    });
+
+    ['screen', 'window'].forEach((mediaSource) => {
+      it('calls getUserMedia with the given default mediaSource', () => {
+        shim.shimGetDisplayMedia(window, mediaSource);
+        window.navigator.mediaDevices.getDisplayMedia({video: true});
+        expect(window.navigator.mediaDevices.getUserMedia)
+          .to.have.been.calledWith({video: {mediaSource}});
+      });
+    });
+  });
+});


### PR DESCRIPTION
fixes #896 -- quite notably this is not backward compatible but this is on the ES6 master branch.

The backport to 6.x will need to consider navigator.getDisplayMedia.