### PR TITLE
Add eslint rule to enforce ASCII-only identifiers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,11 @@
     "default-case": 2,
     "dot-notation": 2,
     "eqeqeq": 2,
+    "id-match": ["error", "^[\x00-\x7F]+$", {
+        "properties": true,
+        "onlyDeclarations": false,
+        "ignoreDestructuring": false
+    }],
     "indent": [
         2,
         2,


### PR DESCRIPTION
**Description**

Adds eslint rule to enforce that all JS identifiers are ASCII-only.

**Purpose**

Prevent the introduction of confusable Unicode characters, as in https://github.com/webrtcHacks/adapter/issues/900