### PR TITLE
chrome/firefox: shim connectionState

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -55,6 +55,7 @@ export function adapterFactory({window} = {}, options = {
       chromeShim.fixNegotiationNeeded(window);
 
       commonShim.shimRTCIceCandidate(window);
+      commonShim.shimConnectionState(window);
       commonShim.shimMaxMessageSize(window);
       commonShim.shimSendThrowTypeError(window);
       break;
@@ -77,6 +78,7 @@ export function adapterFactory({window} = {}, options = {
       firefoxShim.shimRTCDataChannel(window);
 
       commonShim.shimRTCIceCandidate(window);
+      commonShim.shimConnectionState(window);
       commonShim.shimMaxMessageSize(window);
       commonShim.shimSendThrowTypeError(window);
       break;

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -232,3 +232,67 @@ export function shimSendThrowTypeError(window) {
     return e;
   });
 }
+
+
+/* shims RTCConnectionState by pretending it is the same as iceConnectionState.
+ * See https://bugs.chromium.org/p/webrtc/issues/detail?id=6145#c12
+ * for why this is a valid hack in Chrome. In Firefox it is slightly incorrect
+ * since DTLS failures would be hidden. See
+ * https://bugzilla.mozilla.org/show_bug.cgi?id=1265827
+ * for the Firefox tracking bug.
+ */
+export function shimConnectionState(window) {
+  if (!window.RTCPeerConnection ||
+      'connectionState' in window.RTCPeerConnection.prototype) {
+    return;
+  }
+  const proto = window.RTCPeerConnection.prototype;
+  Object.defineProperty(proto, 'connectionState', {
+    get() {
+      return {
+        completed: 'connected',
+        checking: 'connecting'
+      }[this.iceConnectionState] || this.iceConnectionState;
+    },
+    enumerable: true,
+    configurable: true
+  });
+  Object.defineProperty(proto, 'onconnectionstatechange', {
+    get() {
+      return this._onconnectionstatechange || null;
+    },
+    set(cb) {
+      if (this._onconnectionstatechange) {
+        this.removeEventListener('connectionstatechange',
+            this._onconnectionstatechange);
+        delete this._onconnectionstatechange;
+      }
+      if (cb) {
+        this.addEventListener('connectionstatechange',
+            this._onconnectionstatechange = cb);
+      }
+    },
+    enumerable: true,
+    configurable: true
+  });
+
+  ['setLocalDescription', 'setRemoteDescription'].forEach((method) => {
+    const origMethod = proto[method];
+    proto[method] = function() {
+      if (!this._connectionstatechangepoly) {
+        this._connectionstatechangepoly = e => {
+          const pc = e.target;
+          if (pc._lastConnectionState !== pc.connectionState) {
+            pc._lastConnectionState = pc.connectionState;
+            const newEvent = new Event('connectionstatechange', e);
+            pc.dispatchEvent(newEvent);
+          }
+          return e;
+        };
+        this.addEventListener('iceconnectionstatechange',
+          this._connectionstatechangepoly);
+      }
+      return origMethod.apply(this, arguments);
+    };
+  });
+}

--- a/test/e2e/connection.js
+++ b/test/e2e/connection.js
@@ -284,4 +284,20 @@ describe('establishes a connection', () => {
     })
     .catch(throwError);
   });
+
+  it('and triggers the connectionstatechange event', (done) => {
+    pc1.onconnectionstatechange = function() {
+      if (pc1.connectionState === 'connected') {
+        done();
+      }
+    };
+
+    var constraints = {video: true};
+    navigator.mediaDevices.getUserMedia(constraints)
+    .then(function(stream) {
+      pc1.addStream(stream);
+      return negotiate(pc1, pc2);
+    })
+    .catch(throwError);
+  });
 });


### PR DESCRIPTION
**Description**
shims connectionState as iceConnectionState. In Chrome this is what
the iceConnectionState exposed (wrongly). In Firefox it is slightly
incorrect but DTLS failures are going to be rare.

Fixes #909

**Purpose**
This allows updating code that uses iceconnectionstatechange as signal for "you are connected" to be updated to the more correct connectionstatechange