### PR TITLE
Fix overconstraint error due to undefineds on safari

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -189,6 +189,15 @@ export function shimCallbacksAPI(window) {
 export function shimGetUserMedia(window) {
   const navigator = window && window.navigator;
 
+  if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+    // shim not needed in Safari 12.1
+    const mediaDevices = navigator.mediaDevices;
+    const _getUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
+    navigator.mediaDevices.getUserMedia = (constraints) => {
+      return _getUserMedia(shimConstraints(constraints));
+    };
+  }
+
   if (!navigator.getUserMedia && navigator.mediaDevices &&
     navigator.mediaDevices.getUserMedia) {
     navigator.getUserMedia = function(constraints, cb, errcb) {
@@ -196,6 +205,17 @@ export function shimGetUserMedia(window) {
       .then(cb, errcb);
     }.bind(navigator);
   }
+}
+
+export function shimConstraints(constraints) {
+  if (constraints && constraints.video !== undefined) {
+    return Object.assign({},
+      constraints,
+      {video: utils.compactObject(constraints.video)}
+    );
+  }
+
+  return constraints;
 }
 
 export function shimRTCIceServerUrls(window) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -171,3 +171,25 @@ export function detectBrowser(window) {
 
   return result;
 }
+
+/**
+ * Remove all empty objects and undefined values
+ * from a nested object -- an enhanced and vanilla version
+ * of Lodash's `compact`.
+ */
+export function compactObject(data) {
+  if (typeof data !== 'object') {
+    return data;
+  }
+
+  return Object.keys(data).reduce(function(accumulator, key) {
+    const isObject = typeof data[key] === 'object';
+    const value = isObject ? compactObject(data[key]) : data[key];
+    const isEmptyObject = isObject && !Object.keys(value).length;
+    if (value === undefined || isEmptyObject) {
+      return accumulator;
+    }
+
+    return Object.assign(accumulator, {[key]: value});
+  }, {});
+}


### PR DESCRIPTION
**Description**
On the latest build, without this PR, this following code breaks on Safari but works fine on other browsers:

```html
<video id="video" width="250px" autoplay autoplay></video>
```

```js
        var constraints = {
            audio: false,
            video: {
                width: {
                    min: undefined,
                    max: undefined,
                },
                height: {
                    min: undefined,
                    max: undefined,
                },
            },
        };

        navigator.mediaDevices.getUserMedia(constraints).then(function(stream) {
            document.getElementById('video').srcObject = stream;
        }).catch(console.error);
```

It throws errors about overconstrained `undefined` dimensions only for Safari, so I'm cleaning the video constraints from any `undefined` value in its object.

**Purpose**
Fix exactly the scenario I described without breaking any other use case for `getUserMedia` or trying to search/cover other constraint types. It is a very different behavior between browsers, and I'm trying to see what happens in this first contribution mine.
