### PR TITLE
chrome: move getStats shim to separate function

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -51,6 +51,7 @@ export function adapterFactory({window} = {}, options = {
       chromeShim.shimOnTrack(window);
       chromeShim.shimAddTrackRemoveTrack(window);
       chromeShim.shimGetSendersWithDtmf(window);
+      chromeShim.shimGetStats(window);
       chromeShim.shimSenderReceiverGetStats(window);
       chromeShim.fixNegotiationNeeded(window);
 

--- a/test/unit/chrome.js
+++ b/test/unit/chrome.js
@@ -64,7 +64,7 @@ describe('Chrome shim', () => {
           ]
         });
       };
-      shim.shimPeerConnection(window);
+      shim.shimGetStats(window);
       pc = new window.RTCPeerConnection();
     });
 


### PR DESCRIPTION
this was in the current function because this was a legacy monolith