### PR TITLE
test: fix hasOwnProperty test

### DIFF
--- a/test/e2e/expectations/chrome-beta
+++ b/test/e2e/expectations/chrome-beta
@@ -1,1 +1,0 @@
-ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError

--- a/test/e2e/expectations/chrome-beta-no-experimental
+++ b/test/e2e/expectations/chrome-beta-no-experimental
@@ -1,1 +1,0 @@
-ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError

--- a/test/e2e/expectations/chrome-unstable
+++ b/test/e2e/expectations/chrome-unstable
@@ -1,1 +1,0 @@
-ERR RTCIceCandidate with empty candidate.candidate does not throw AssertionError

--- a/test/e2e/rtcicecandidate.js
+++ b/test/e2e/rtcicecandidate.js
@@ -15,14 +15,14 @@ describe('RTCIceCandidate', () => {
 
   describe('is augmented in', () => {
     it('the onicecandidate callback', (done) => {
-      let hasProperty = false;
+      let hasAddress = false;
       const pc = new window.RTCPeerConnection();
       pc.onicecandidate = (e) => {
         if (!e.candidate) {
-          expect(hasProperty).to.equal(true);
+          expect(hasAddress).to.equal(true);
           done();
         } else {
-          hasProperty = e.candidate.hasOwnProperty('address');
+          hasAddress = !!e.candidate.address;
         }
       };
       pc.createOffer({offerToReceiveAudio: true})
@@ -30,14 +30,14 @@ describe('RTCIceCandidate', () => {
     });
 
     it('the icecandidate event', (done) => {
-      let hasProperty = false;
+      let hasAddress = false;
       const pc = new window.RTCPeerConnection();
       pc.addEventListener('icecandidate', (e) => {
         if (!e.candidate) {
-          expect(hasProperty).to.equal(true);
+          expect(hasAddress).to.equal(true);
           done();
         } else {
-          hasProperty = e.candidate.hasOwnProperty('port');
+          hasAddress = !!e.candidate.address;
         }
       });
       pc.createOffer({offerToReceiveAudio: true})


### PR DESCRIPTION
chrome beta/unstable fail the ice candidate augmentation test since hasOwnProperty('address') fails even though candidate.address is set. Changes the test to avoid this.

@jan-ivar while its Chrome, do you understand this? Was the test semantics (it continues to work in Firefox) wrong?