### PR TITLE
drop support for insecure contexts

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -144,6 +144,11 @@ export function detectBrowser(window) {
     return result;
   }
 
+  if (window.isSecureContext === false) {
+    result.browser = 'Insecure Contexts are no longer supported.';
+    return result;
+  }
+
   if (navigator.mozGetUserMedia) { // Firefox.
     result.browser = 'firefox';
     result.version = extractVersion(navigator.userAgent,


### PR DESCRIPTION
getUserMedia was recently made [SecureContext] and does not exist when running on http. This lead, similar to the scenario in #764 to Chrome being detected as Safari, activating the wrong shims.

RTCPeerConnection will still be available but can only be used for datachannels and receive-only contexts where adapter doesn't offer much benefit.

Fixes #935, requires a major version bump.