### PR TITLE
Safari: Only compact objects in the constraints.

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -177,23 +177,32 @@ export function detectBrowser(window) {
 }
 
 /**
+ * Checks if something is an object.
+ *
+ * @param {*} val The something you want to check.
+ * @return true if val is an object, false otherwise.
+ */
+function isObject(val) {
+  return Object.prototype.toString.call(val) === '[object Object]';
+}
+
+/**
  * Remove all empty objects and undefined values
  * from a nested object -- an enhanced and vanilla version
  * of Lodash's `compact`.
  */
 export function compactObject(data) {
-  if (typeof data !== 'object') {
+  if (!isObject(data)) {
     return data;
   }
 
   return Object.keys(data).reduce(function(accumulator, key) {
-    const isObject = typeof data[key] === 'object';
-    const value = isObject ? compactObject(data[key]) : data[key];
-    const isEmptyObject = isObject && !Object.keys(value).length;
+    const isObj = isObject(data[key]);
+    const value = isObj ? compactObject(data[key]) : data[key];
+    const isEmptyObject = isObj && !Object.keys(value).length;
     if (value === undefined || isEmptyObject) {
       return accumulator;
     }
-
     return Object.assign(accumulator, {[key]: value});
   }, {});
 }

--- a/test/unit/compactObject.js
+++ b/test/unit/compactObject.js
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+/* eslint-env node */
+const chai = require('chai');
+const expect = chai.expect;
+
+describe('compactObject', () => {
+  const compactObject = require('../../dist/utils.js').compactObject;
+
+  it('returns an empty object as is', () => {
+    expect(compactObject({})).to.deep.equal({});
+  });
+
+  it('removes undefined values', () => {
+    expect(compactObject({
+      nothing: undefined,
+      value: 'hello',
+      something: undefined,
+    })).to.deep.equal({
+      value: 'hello',
+    });
+  });
+
+  it('removes nested empty objects', () => {
+    expect(compactObject({
+      nothing: {},
+      val: 12,
+    })).to.deep.equal({
+      val: 12,
+    });
+  });
+
+  it('removes nested undefined values', () => {
+    expect(compactObject({
+      value: 'hello',
+      something: {
+        nestedValue: 12,
+        nestedEmpty: {},
+        nestedNothing: undefined,
+      },
+    })).to.deep.equal({
+      value: 'hello',
+      something: {
+        nestedValue: 12,
+      },
+    });
+  });
+
+  it('leaves arrays alone', () => {
+    const arr = [{val: 'hello'}, undefined, 525];
+    expect(compactObject({
+      nothing: undefined,
+      value: arr,
+      something: undefined,
+    })).to.deep.equal({
+      value: arr,
+    });
+  });
+});


### PR DESCRIPTION
**Description**
Modified the isObject check in compactObject to properly identify objects.

**Purpose**
Adding the advanced property to the constraints object caused an error in Safari, since compactObject converted it to an object with keys 0, 1 and so on. This update fixes the isObject check so that only proper objects are compacted.

Also, passing in null would cause an error to be thrown previously (since isObject was true)