### PR TITLE
test: modify "candidate has address" test

### DIFF
--- a/test/e2e/rtcicecandidate.js
+++ b/test/e2e/rtcicecandidate.js
@@ -19,10 +19,10 @@ describe('RTCIceCandidate', () => {
       const pc = new window.RTCPeerConnection();
       pc.onicecandidate = (e) => {
         if (!e.candidate) {
-          expect(hasAddress).to.equal(true);
+          expect(hasAddress).to.equal(1);
           done();
         } else {
-          hasAddress = !!e.candidate.address;
+          hasAddress |= !!e.candidate.address;
         }
       };
       pc.createOffer({offerToReceiveAudio: true})
@@ -34,10 +34,10 @@ describe('RTCIceCandidate', () => {
       const pc = new window.RTCPeerConnection();
       pc.addEventListener('icecandidate', (e) => {
         if (!e.candidate) {
-          expect(hasAddress).to.equal(true);
+          expect(hasAddress).to.equal(1);
           done();
         } else {
-          hasAddress = !!e.candidate.address;
+          hasAddress |= !!e.candidate.address;
         }
       });
       pc.createOffer({offerToReceiveAudio: true})


### PR DESCRIPTION
Modifies the "does RTCIceCandidate have an address" test to work with Firefox nightly which generates candidates with candidate: ""

(tests will still fail in Nightly due to #958)