### PR TITLE
test: change msid test

### DIFF
--- a/test/e2e/msid.js
+++ b/test/e2e/msid.js
@@ -53,7 +53,7 @@ describe('MSID', () => {
     });
   });
 
-  it('puts the track msid attribute into the localDescription', () => {
+  it('puts the stream msid attribute into the localDescription', () => {
     return navigator.mediaDevices.getUserMedia({video: true})
     .then((stream) => {
       localStream = stream;
@@ -61,9 +61,8 @@ describe('MSID', () => {
       return negotiate(pc1, pc2);
     })
     .then(() => {
-      const track = localStream.getTracks()[0];
       expect(pc1.localDescription.sdp)
-          .to.contain('msid:' + localStream.id + ' ' + track.id);
+          .to.contain('msid:' + localStream.id + ' ');
     });
   });
 });


### PR DESCRIPTION
changes the msid test since Firefox no longer puts the track id into the local sdp
Fixes #958

(FF nightly test is still going to fail due to #959)