### PR TITLE
test: fail if FF nightly fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
 
   allow_failures:
     - env: BROWSER=chrome  BVER=unstable
-    - env: BROWSER=firefox BVER=nightly
 
 before_script:
   - export CHROME_BIN=browsers/bin/chrome-${BVER}


### PR DESCRIPTION
nightly seems to be pretty stable these days. Failing in nightly will point out changes like #960 faster

@jan-ivar I assume that I can always nag you when things start failing :-)