### PR TITLE
test: fail if chrome unstable fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ env:
 matrix:
   fast_finish: true
 
-  allow_failures:
-    - env: BROWSER=chrome  BVER=unstable
-
 before_script:
   - export CHROME_BIN=browsers/bin/chrome-${BVER}
   - export FIREFOX_BIN=browsers/bin/firefox-${BVER}


### PR DESCRIPTION
the iceconnectionstate issue #956 would have been discovered a bit earlier if the cron jobs had failed earlier. They didn't because Chrome unstable was allowed to fail. Don't allow this similar to #961