### PR TITLE
Only filter 'turns:' and turn/stun with ipv6

### DIFF
--- a/src/js/edge/filtericeservers.js
+++ b/src/js/edge/filtericeservers.js
@@ -28,19 +28,8 @@ export function filterIceServers(iceServers, edgeVersion) {
         urls = [urls];
       }
       urls = urls.filter(url => {
-        // filter STUN unconditionally.
-        if (url.indexOf('stun:') === 0) {
-          return false;
-        }
-
-        const validTurn = url.startsWith('turn') &&
-            !url.startsWith('turn:[') &&
-            url.includes('transport=udp');
-        if (validTurn && !hasTurn) {
-          hasTurn = true;
-          return true;
-        }
-        return validTurn && !hasTurn;
+        // Make sure only 'turn:' and 'stun:', ipV4 only, pass. 'turns:' is not supported by edge 
+        return ((url.startsWith('turn:') && !url.startsWith('turn:[')) || (url.startsWith('stun:') && !url.startsWith('stun:[')));
       });
 
       delete server.url;


### PR DESCRIPTION
**Description**
This PR should fix the filter function properly. It was tested against Edge 15/16/17/18. In all 4 version only the turns: protocol turned out to be not supported by edge (throwing an exception).
Also the stun protocol seems to be supported, at least no  exception and everything works as expected.

**Purpose**
Should make the filterfunction not so restrictive.