### PR TITLE
safari: keep audio-video order in legacy addStream

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -29,7 +29,12 @@ export function shimLocalStreamsAPI(window) {
       if (!this._localStreams.includes(stream)) {
         this._localStreams.push(stream);
       }
-      stream.getTracks().forEach(track => _addTrack.call(this, track, stream));
+      // Try to emulate Chrome's behaviour of adding in audio-video order.
+      // Safari orders by track id.
+      stream.getAudioTracks().forEach(track => _addTrack.call(this, track,
+        stream));
+      stream.getVideoTracks().forEach(track => _addTrack.call(this, track,
+        stream));
     };
 
     window.RTCPeerConnection.prototype.addTrack = function(track, stream) {

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -39,12 +39,13 @@ describe('Safari shim', () => {
     });
     it('local streams API', () => {
       const pc = new window.RTCPeerConnection();
-      pc.getSenders = () => {
-        return [];
+      pc.getSenders = () => [];
+      const stream = {
+        id: 'id1',
+        getTracks: () => [],
+        getAudioTracks: () => [],
+        getVideoTracks: () => [],
       };
-      var stream = {id: 'id1', getTracks: () => {
-        return [];
-      }};
       expect(pc.getLocalStreams().length).to.equal(0);
       expect(pc.getRemoteStreams().length).to.equal(0);
 
@@ -52,7 +53,12 @@ describe('Safari shim', () => {
       expect(pc.getLocalStreams()[0]).to.equal(stream);
       expect(pc.getRemoteStreams().length).to.equal(0);
 
-      var stream2 = {id: 'id2', getTracks: stream.getTracks};
+      const stream2 = {
+        id: 'id2',
+        getTracks: () => [],
+        getAudioTracks: () => [],
+        getVideoTracks: () => [],
+      };
       pc.removeStream(stream2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);
 


### PR DESCRIPTION
suggested here: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/discuss-webrtc/aUrQ4FJ5Br0/QvlG8WtACQAJ
