### PR TITLE
point to dist/adapter_core.js in package.json main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "7.2.4",
   "description": "A shim to insulate apps from WebRTC spec changes and browser prefix differences",
   "license": "BSD-3-Clause",
-  "main": "./src/js/adapter_core5.js",
+  "main": "./dist/adapter_core.js",
   "module": "./src/js/adapter_core.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
points main in package.json to the es5-transpiled version of adapter.
Partial fix for #970