### PR TITLE
ignore addIceCandidate({candidate: ''}) in FF<68 and Chrome <78

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -702,6 +702,12 @@ export function shimPeerConnection(window) {
         }
         return Promise.resolve();
       }
+      // Firefox 68+ emits and processes {candidate: "", ...}, ignore
+      // in older versions. Native support planned for Chrome M77.
+      if (browserDetails.version < 78 &&
+        arguments[0] && arguments[0].candidate === '') {
+        return Promise.resolve();
+      }
       return nativeAddIceCandidate.apply(this, arguments);
     };
 }

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -62,6 +62,12 @@ export function shimPeerConnection(window) {
       }
       return Promise.resolve();
     }
+    // Firefox 68+ emits and processes {candidate: "", ...}, ignore
+    // in older versions.
+    if (browserDetails.version < 68 &&
+      arguments[0] && arguments[0].candidate === '') {
+      return Promise.resolve();
+    }
     return nativeAddIceCandidate.apply(this, arguments);
   };
 

--- a/test/e2e/addIceCandidate.js
+++ b/test/e2e/addIceCandidate.js
@@ -50,5 +50,9 @@ describe('addIceCandidate', () => {
     it('resolves when called with undefined', () =>
       pc.addIceCandidate(undefined)
     );
+
+    it('resolves when called with {candidate: \'\'}', () =>
+      pc.addIceCandidate({candidate: '', sdpMid: 'mid1'})
+    );
   });
 });


### PR DESCRIPTION
Ignores addIceCandidate({candidate: ''}) in Firefox up to version 68 which
emits this.

Also done in Chrome < 78, see https://bugs.chromium.org/p/chromium/issues/detail?id=978582