### PR TITLE
safari: fix trackevent transceiver property

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -267,11 +267,9 @@ export function shimRTCIceServerUrls(window) {
 
 export function shimTrackEventTransceiver(window) {
   // Add event.transceiver member over deprecated event.receiver
-  if (typeof window === 'object' && window.RTCPeerConnection &&
-      ('receiver' in window.RTCTrackEvent.prototype) &&
-      // can't check 'transceiver' in window.RTCTrackEvent.prototype, as it is
-      // defined for some reason even when window.RTCTransceiver is not.
-      !window.RTCTransceiver) {
+  if (typeof window === 'object' && window.RTCTrackEvent &&
+      'receiver' in window.RTCTrackEvent.prototype &&
+      !('transceiver' in window.RTCTrackEvent.prototype)) {
     Object.defineProperty(window.RTCTrackEvent.prototype, 'transceiver', {
       get() {
         return {receiver: this.receiver};


### PR DESCRIPTION
Fixes #984.

Test Plan:
- verify that 'transceiver' in RTCTrackEvent.prototype works in current safari
- call SRD with a SDP that will trigger ontrack
- inspect track event, look at transceiver property