### PR TITLE
safari: fix addTrack polyfill

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -48,7 +48,7 @@ export function shimLocalStreamsAPI(window) {
             this._localStreams.push(stream);
           }
         }
-        return _addTrack.call(this, arguments);
+        return _addTrack.call(this, ...arguments);
       };
   }
   if (!('removeStream' in window.RTCPeerConnection.prototype)) {


### PR DESCRIPTION
Fixes an issue with #990 (which did not fix #989) since Safari behaves differently when passing `arguments`