### PR TITLE
Utils can throw an exception trying to redfined a property wrapper

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -61,6 +61,10 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
       unwrappedCb]);
   };
 
+  if (Object.getOwnPropertyNames(proto).indexOf('on' + eventNameToWrap) != -1) {
+    return;
+  }
+  
   Object.defineProperty(proto, 'on' + eventNameToWrap, {
     get() {
       return this['_on' + eventNameToWrap];

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -61,10 +61,10 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
       unwrappedCb]);
   };
 
-  if (Object.getOwnPropertyNames(proto).indexOf('on' + eventNameToWrap) != -1) {
+  if (Object.getOwnPropertyNames(proto).indexOf('on' + eventNameToWrap) !== -1) {
     return;
   }
-  
+
   Object.defineProperty(proto, 'on' + eventNameToWrap, {
     get() {
       return this['_on' + eventNameToWrap];


### PR DESCRIPTION
**Description**

When utils tries to define a property it can try to define an already existing property, thus throwing an exception.

I ran into this issue using the atom-hydra package

[atom-hyra related issue](https://github.com/ojack/atom-hydra/issues/13)

I can't find anything that would be lost by not redefining the event in looking at this code. Happy to address any issues that might need to be resolved.

**Purpose**

Stop utils from redefining a property that already exists.
