### PR TITLE
Check if e.candidate is empty string in icecandidate listener

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -53,7 +53,7 @@ export function shimRTCIceCandidate(window) {
   // Hook up the augmented candidate in onicecandidate and
   // addEventListener('icecandidate', ...)
   utils.wrapPeerConnectionEvent(window, 'icecandidate', e => {
-    if (e.candidate) {
+    if (e.candidate && e.candidate.length) {
       Object.defineProperty(e, 'candidate', {
         value: new window.RTCIceCandidate(e.candidate),
         writable: 'false'


### PR DESCRIPTION
We were facing this issue, if icecandidate events created with an empty string, errors occurred in other functions called by this method. This solution solved it.