### PR TITLE
travis: allow FF ESR to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
-    - env: BROWSER=firefox BVER=stable
+    - env: BROWSER=firefox BVER=esr
 
 before_script:
   - export CHROME_BIN=browsers/bin/chrome-${BVER}


### PR DESCRIPTION
due to flakiness. FF stable is required to pass again