### PR TITLE
chrome: don't ignore addIceCandidate() if native does

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -675,6 +675,9 @@ export function shimPeerConnection(window) {
     return;
   }
 
+  const addIceCandidateNullSupported =
+    window.RTCPeerConnection.prototype.addIceCandidate.length === 0;
+
   // shim implicit creation of RTCSessionDescription/RTCIceCandidate
   if (browserDetails.version < 53) {
     ['setLocalDescription', 'setRemoteDescription', 'addIceCandidate']
@@ -695,7 +698,7 @@ export function shimPeerConnection(window) {
       window.RTCPeerConnection.prototype.addIceCandidate;
   window.RTCPeerConnection.prototype.addIceCandidate =
     function addIceCandidate() {
-      if (!arguments[0]) {
+      if (!addIceCandidateNullSupported && !arguments[0]) {
         if (arguments[1]) {
           arguments[1].apply(null);
         }


### PR DESCRIPTION
This will make more code obsolete once
  https://bugs.chromium.org/p/chromium/issues/detail?id=1040882
gets fixed