### PR TITLE
Fix. "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context, when using addTrack() method"

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -39,7 +39,7 @@ export function shimLocalStreamsAPI(window) {
     };
 
     window.RTCPeerConnection.prototype.addTrack =
-      function addTrack(track, stream) {
+      function addTrack(track, ...stream) {
         if (stream) {
           if (!this._localStreams) {
             this._localStreams = [stream];

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -21,20 +21,6 @@ export function shimLocalStreamsAPI(window) {
         return this._localStreams;
       };
   }
-  if (!('addTrack' in window.RTCPeerConnection.prototype)) {
-    const _addTrack = window.RTCPeerConnection.prototype.addTrack;
-    window.RTCPeerConnection.prototype.addTrack = function addTrack(track) {
-      const stream = arguments[1];
-      if (stream) {
-        if (!this._localStreams) {
-          this._localStreams = [stream];
-        } else if (!this._localStreams.includes(stream)) {
-          this._localStreams.push(stream);
-        }
-      }
-      return _addTrack.apply(this, arguments);
-    };
-  }
   if (!('addStream' in window.RTCPeerConnection.prototype)) {
     const _addTrack = window.RTCPeerConnection.prototype.addTrack;
     window.RTCPeerConnection.prototype.addStream = function addStream(stream) {
@@ -50,6 +36,17 @@ export function shimLocalStreamsAPI(window) {
         stream));
       stream.getVideoTracks().forEach(track => _addTrack.call(this, track,
         stream));
+    };
+
+    window.RTCPeerConnection.prototype.addTrack = function addTrack(track, stream) {
+      if (stream) {
+        if (!this._localStreams) {
+          this._localStreams = [stream];
+        } else if (!this._localStreams.includes(stream)) {
+          this._localStreams.push(stream);
+        }
+      }
+      return _addTrack.apply(this, arguments);
     };
   }
   if (!('removeStream' in window.RTCPeerConnection.prototype)) {

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -39,13 +39,13 @@ export function shimLocalStreamsAPI(window) {
     };
 
     window.RTCPeerConnection.prototype.addTrack =
-      function addTrack(track, ...stream) {
-        if (stream) {
-          stream.forEach((s) => {
+      function addTrack(track, ...streams) {
+        if (streams) {
+          streams.forEach((stream) => {
             if (!this._localStreams) {
-              this._localStreams = [s];
-            } else if (!this._localStreams.includes(s)) {
-              this._localStreams.push(s);
+              this._localStreams = [stream];
+            } else if (!this._localStreams.includes(stream)) {
+              this._localStreams.push(stream);
             }
           });
         }

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -41,11 +41,13 @@ export function shimLocalStreamsAPI(window) {
     window.RTCPeerConnection.prototype.addTrack =
       function addTrack(track, ...stream) {
         if (stream) {
-          if (!this._localStreams) {
-            this._localStreams = [stream];
-          } else if (!this._localStreams.includes(stream)) {
-            this._localStreams.push(stream);
-          }
+          stream.forEach((s) => {
+            if (!this._localStreams) {
+              this._localStreams = [s];
+            } else if (!this._localStreams.includes(s)) {
+              this._localStreams.push(s);
+            }
+          });
         }
         return _addTrack.apply(this, arguments);
       };

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -38,7 +38,7 @@ export function shimLocalStreamsAPI(window) {
         stream));
     };
 
-    window.RTCPeerConnection.prototype.addTrack = 
+    window.RTCPeerConnection.prototype.addTrack =
       function addTrack(track, stream) {
         if (stream) {
           if (!this._localStreams) {

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -21,6 +21,19 @@ export function shimLocalStreamsAPI(window) {
         return this._localStreams;
       };
   }
+  if (!('addTrack' in window.RTCPeerConnection.prototype)) {
+    window.RTCPeerConnection.prototype.addTrack = function addTrack(track) {
+      const stream = arguments[1];
+      if (stream) {
+        if (!this._localStreams) {
+          this._localStreams = [stream];
+        } else if (!this._localStreams.includes(stream)) {
+          this._localStreams.push(stream);
+        }
+      }
+      return _addTrack.apply(this, arguments);
+    };
+  }
   if (!('addStream' in window.RTCPeerConnection.prototype)) {
     const _addTrack = window.RTCPeerConnection.prototype.addTrack;
     window.RTCPeerConnection.prototype.addStream = function addStream(stream) {
@@ -37,19 +50,6 @@ export function shimLocalStreamsAPI(window) {
       stream.getVideoTracks().forEach(track => _addTrack.call(this, track,
         stream));
     };
-
-    window.RTCPeerConnection.prototype.addTrack =
-      function addTrack(track) {
-        const stream = arguments[1];
-        if (stream) {
-          if (!this._localStreams) {
-            this._localStreams = [stream];
-          } else if (!this._localStreams.includes(stream)) {
-            this._localStreams.push(stream);
-          }
-        }
-        return _addTrack.apply(this, arguments);
-      };
   }
   if (!('removeStream' in window.RTCPeerConnection.prototype)) {
     window.RTCPeerConnection.prototype.removeStream =

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -22,6 +22,7 @@ export function shimLocalStreamsAPI(window) {
       };
   }
   if (!('addTrack' in window.RTCPeerConnection.prototype)) {
+    const _addTrack = window.RTCPeerConnection.prototype.addTrack;
     window.RTCPeerConnection.prototype.addTrack = function addTrack(track) {
       const stream = arguments[1];
       if (stream) {

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -38,16 +38,17 @@ export function shimLocalStreamsAPI(window) {
         stream));
     };
 
-    window.RTCPeerConnection.prototype.addTrack = function addTrack(track, stream) {
-      if (stream) {
-        if (!this._localStreams) {
-          this._localStreams = [stream];
-        } else if (!this._localStreams.includes(stream)) {
-          this._localStreams.push(stream);
+    window.RTCPeerConnection.prototype.addTrack = 
+      function addTrack(track, stream) {
+        if (stream) {
+          if (!this._localStreams) {
+            this._localStreams = [stream];
+          } else if (!this._localStreams.includes(stream)) {
+            this._localStreams.push(stream);
+          }
         }
-      }
-      return _addTrack.apply(this, arguments);
-    };
+        return _addTrack.apply(this, arguments);
+      };
   }
   if (!('removeStream' in window.RTCPeerConnection.prototype)) {
     window.RTCPeerConnection.prototype.removeStream =

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -63,7 +63,7 @@ describe('Safari shim', () => {
       expect(pc.getLocalStreams()[0]).to.equal(stream);
 
       pc.addTrack({}, stream2);
-      expect(pc.getLocalStreams().length).to.equal(1);
+      expect(pc.getLocalStreams().length).to.equal(2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);
       expect(pc.getLocalStreams()[1]).to.equal(stream2);
 

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -63,7 +63,7 @@ describe('Safari shim', () => {
       expect(pc.getLocalStreams()[0]).to.equal(stream);
 
       pc.addTrack({}, stream2);
-      expect(pc.getLocalStreams().length).to.equal(2);
+      expect(pc.getLocalStreams().length).to.equal(1);
       expect(pc.getLocalStreams()[0]).to.equal(stream);
       expect(pc.getLocalStreams()[1]).to.equal(stream2);
 

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -24,6 +24,7 @@ describe('Safari shim', () => {
 
   describe('shimStreamsAPI', () => {
     beforeEach(() => {
+      window.RTCPeerConnection.prototype.addTrack = sinon.stub();
       shim.shimLocalStreamsAPI(window);
       shim.shimRemoteStreamsAPI(window);
     });
@@ -61,7 +62,6 @@ describe('Safari shim', () => {
       pc.removeStream(stream2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);
 
-      window.RTCPeerConnection.prototype.addTrack = sinon.stub();
       pc.addTrack({}, stream2);
       expect(pc.getLocalStreams().length).to.equal(2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -61,6 +61,7 @@ describe('Safari shim', () => {
       pc.removeStream(stream2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);
 
+      window.RTCPeerConnection.prototype.addTrack = sinon.stub();
       pc.addTrack({}, stream2);
       expect(pc.getLocalStreams().length).to.equal(2);
       expect(pc.getLocalStreams()[0]).to.equal(stream);

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -31,7 +31,7 @@ describe('Safari shim', () => {
 
     it('shimStreamsAPI existence', () => {
       const prototype = window.RTCPeerConnection.prototype;
-      expect(prototype.addTrack.length).to.equal(2);
+      expect(prototype.addTrack.length).to.equal(1);
       expect(prototype.addStream.length).to.equal(1);
       expect(prototype.removeStream.length).to.equal(1);
       expect(prototype.getLocalStreams.length).to.equal(0);

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -24,7 +24,6 @@ describe('Safari shim', () => {
 
   describe('shimStreamsAPI', () => {
     beforeEach(() => {
-      window.RTCPeerConnection.prototype.addTrack = sinon.stub();
       shim.shimLocalStreamsAPI(window);
       shim.shimRemoteStreamsAPI(window);
     });

--- a/test/unit/safari.js
+++ b/test/unit/safari.js
@@ -31,7 +31,7 @@ describe('Safari shim', () => {
 
     it('shimStreamsAPI existence', () => {
       const prototype = window.RTCPeerConnection.prototype;
-      expect(prototype.addTrack.length).to.equal(1);
+      expect(prototype.addTrack.length).to.equal(2);
       expect(prototype.addStream.length).to.equal(1);
       expect(prototype.removeStream.length).to.equal(1);
       expect(prototype.getLocalStreams.length).to.equal(0);


### PR DESCRIPTION
**Description**
PR to fix the issue "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context, when using addTrack() method" #1023
