### PR TITLE
chrome: only shim when recognizing a version

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -41,6 +41,10 @@ export function adapterFactory({window} = {}, options = {
         logging('Chrome shim is not included in this adapter release.');
         return adapter;
       }
+      if (browserDetails.version === null) {
+        logging('Chrome shim can not determine version, not shimming.');
+        return adapter;
+      }
       logging('adapter.js shimming chrome.');
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = chromeShim;


### PR DESCRIPTION
only do the chrome shim when recognizing the version. This can be misbehaving
when using chrome devtools or when not being able to sniff the version from
the UA string.

Fixes #1030