### PR TITLE
safari: shim window.AudioContext

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -122,6 +122,7 @@ export function adapterFactory({window} = {}, options = {
       safariShim.shimRemoteStreamsAPI(window);
       safariShim.shimTrackEventTransceiver(window);
       safariShim.shimGetUserMedia(window);
+      safariShim.shimAudioContext(window);
 
       commonShim.shimRTCIceCandidate(window);
       commonShim.shimMaxMessageSize(window);

--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -340,3 +340,10 @@ export function shimCreateOfferLegacy(window) {
       return origCreateOffer.apply(this, arguments);
     };
 }
+
+export function shimAudioContext(window) {
+  if (typeof window !== 'object' || window.AudioContext) {
+    return;
+  }
+  window.AudioContext = window.webkitAudioContext;
+}


### PR DESCRIPTION
since its apparently still prefixed in Safari. See
  https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/AudioContext

cc @youennf 