### PR TITLE
build: ignore browser-tmp for npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 browsers/
+browser-tmp/
 firefox-*.tar.bz2
 .DS_Store
 node_modules/


### PR DESCRIPTION
since it may contain leftover installations