### PR TITLE
util: fix wrapPeerConnection

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -40,7 +40,11 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
     const wrappedCallback = (e) => {
       const modifiedEvent = wrapper(e);
       if (modifiedEvent) {
-        cb(modifiedEvent);
+        if (cb.handleEvent) {
+          cb.handleEvent(modifiedEvent);
+        } else {
+          cb(modifiedEvent);
+        }
       }
     };
     this._eventMap = this._eventMap || {};

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -49,9 +49,9 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
     };
     this._eventMap = this._eventMap || {};
     if (!this._eventMap[eventNameToWrap]) {
-      this._eventMap[eventNameToWrap] = [];
+      this._eventMap[eventNameToWrap] = new Map();
     }
-    this._eventMap[eventNameToWrap].push([cb, wrappedCallback]);
+    this._eventMap[eventNameToWrap].set(cb, wrappedCallback);
     return nativeAddEventListener.apply(this, [nativeEventName,
       wrappedCallback]);
   };
@@ -62,15 +62,12 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
         || !this._eventMap[eventNameToWrap]) {
       return nativeRemoveEventListener.apply(this, arguments);
     }
-    const index = this._eventMap[eventNameToWrap].findIndex(([cb_, _]) => {
-      return cb_ === cb;
-    });
-    if (index === -1) {
+    if (!this._eventMap[eventNameToWrap].has(cb)) {
       return nativeRemoveEventListener.apply(this, arguments);
     }
-    const unwrappedCb = this._eventMap[eventNameToWrap][index];
-    this._eventMap[eventNameToWrap].splice(index, 1);
-    if (this._eventMap[eventNameToWrap].length === 0) {
+    const unwrappedCb = this._eventMap[eventNameToWrap].get(cb);
+    this._eventMap[eventNameToWrap].delete(cb);
+    if (this._eventMap[eventNameToWrap].size === 0) {
       delete this._eventMap[eventNameToWrap];
     }
     if (Object.keys(this._eventMap).length === 0) {


### PR DESCRIPTION
so it doesn't blindly assume that the handler is a function
Fixes #1034

Test Plan:
```
class Test {
    constructor() {
        this.pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.l.google.com:19302' }] })
        this.pc.addEventListener('negotiationneeded', this)
        this.pc.createDataChannel('data')
    }
    close() {
        this.pc.removeEventListener('signalingstatechange', this)
        this.pc.close()
    }
    handleEvent(evt) {
        console.log('Received event', evt)
    }
}
const t = new Test(); t.pc.createOffer().then(offer => t.pc.setLocalDescription(offer))
```
shows 'Received event negotiationneeded'