### PR TITLE
safari: dont remove a=extmap-allow-mixed in current safari

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -318,12 +318,15 @@ export function shimConnectionState(window) {
 }
 
 export function removeAllowExtmapMixed(window) {
-  /* remove a=extmap-allow-mixed for Chrome < M71 */
+  /* remove a=extmap-allow-mixed for webrtc.org < M71 */
   if (!window.RTCPeerConnection) {
     return;
   }
   const browserDetails = utils.detectBrowser(window);
   if (browserDetails.browser === 'chrome' && browserDetails.version >= 71) {
+    return;
+  }
+  if (browserDetails.browser === 'safari' && browserDetails.version >= 605) {
     return;
   }
   const nativeSRD = window.RTCPeerConnection.prototype.setRemoteDescription;


### PR DESCRIPTION
which does support parsing the extmap-allow-mixed attribute. See
  https://bugs.chromium.org/p/webrtc/issues/detail?id=9985

@youennf i picked a version I could test. If you know what webkit version actually includes [this commit](https://webrtc.googlesource.com/src.git/+/746dd0dbe60526ec7ce2d3dc8a43d6a66a0187d5) that would be great