### PR TITLE
Shim sender.getParameters() in Firefox to match up w/addTransceiver shim

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -83,6 +83,7 @@ export function adapterFactory({window} = {}, options = {
       firefoxShim.shimReceiverGetStats(window);
       firefoxShim.shimRTCDataChannel(window);
       firefoxShim.shimAddTransceiver(window);
+      firefoxShim.shimGetParameters(window);
       firefoxShim.shimCreateOffer(window);
       firefoxShim.shimCreateAnswer(window);
 


### PR DESCRIPTION
**Description**
Shim sender.getParameters() to include encodings added by addTransceiver(, {sendEncodings}) 

**Purpose**
Fix cases where JS uses setParameters before createOffer/Answer or uses new SLD/SRD wo/arguments.