### PR TITLE
Fixes for running as an isomorphic web app

### DIFF
--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -11,5 +11,6 @@
 
 import {adapterFactory} from './adapter_factory.js';
 
-const adapter = adapterFactory({window: typeof window === 'undefined' ? undefined : window});
+const adapter =
+  adapterFactory({window: typeof window === 'undefined' ? undefined : window});
 export default adapter;

--- a/src/js/adapter_core.js
+++ b/src/js/adapter_core.js
@@ -11,5 +11,5 @@
 
 import {adapterFactory} from './adapter_factory.js';
 
-const adapter = adapterFactory({window});
+const adapter = adapterFactory({window: typeof window === 'undefined' ? undefined : window});
 export default adapter;

--- a/src/js/adapter_core5.js
+++ b/src/js/adapter_core5.js
@@ -11,5 +11,6 @@
 
 import {adapterFactory} from './adapter_factory.js';
 
-const adapter = adapterFactory({window: typeof window === 'undefined' ? undefined : window});
+const adapter =
+  adapterFactory({window: typeof window === 'undefined' ? undefined : window});
 module.exports = adapter; // this is the difference from adapter_core.

--- a/src/js/adapter_core5.js
+++ b/src/js/adapter_core5.js
@@ -11,5 +11,5 @@
 
 import {adapterFactory} from './adapter_factory.js';
 
-const adapter = adapterFactory({window});
+const adapter = adapterFactory({window: typeof window === 'undefined' ? undefined : window});
 module.exports = adapter; // this is the difference from adapter_core.

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -149,8 +149,6 @@ export function deprecated(oldMethod, newMethod) {
  *     properties.
  */
 export function detectBrowser(window) {
-  const {navigator} = window;
-
   // Returned result object.
   const result = {browser: null, version: null};
 
@@ -159,6 +157,8 @@ export function detectBrowser(window) {
     result.browser = 'Not a browser.';
     return result;
   }
+
+  const {navigator} = window;
 
   if (navigator.mozGetUserMedia) { // Firefox.
     result.browser = 'firefox';


### PR DESCRIPTION
When running as an isomorphic web app, a window might not exist.  In fact, the window object might not even exist - so the first thing that happens needs to be a check for existence, before peeling off the navigator, since that might not even exist.