### PR TITLE
Add default encodings[0] to getParameters() when missing in Firefox.

### DIFF
--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -263,7 +263,7 @@ export function shimGetParameters(window) {
   if (origGetParameters) {
     window.RTCRtpSender.prototype.getParameters =
       function getParameters() {
-        var params = origGetParameters.apply(this, arguments);
+        const params = origGetParameters.apply(this, arguments);
         if (!('encodings' in params)) {
           params.encodings = [].concat(this.sendEncodings || [{}]);
         }

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -238,7 +238,10 @@ export function shimAddTransceiver(window) {
           // opportunity to recreate offer.
           const {sender} = transceiver;
           const params = sender.getParameters();
-          if (!('encodings' in params)) {
+          if (!('encodings' in params) ||
+              // Avoid being fooled by patched getParameters() below.
+              (params.encodings.length == 1 &&
+               Object.keys(params.encodings[0]).length == 0)) {
             params.encodings = initParameters.sendEncodings;
             sender.sendEncodings = initParameters.sendEncodings;
             this.setParametersPromises.push(sender.setParameters(params)

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -264,10 +264,10 @@ export function shimGetParameters(window) {
     window.RTCRtpSender.prototype.getParameters =
       function getParameters() {
         var params = origGetParameters.apply(this, arguments);
-        if (!('sendEncodings' in this)) {
-          return params;
+        if (!('encodings' in params)) {
+          params.encodings = [].concat(this.sendEncodings || [{}]);
         }
-        return Object.assign({}, {encodings: this.sendEncodings}, params);
+        return params;
       };
   }
 }

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -240,8 +240,8 @@ export function shimAddTransceiver(window) {
           const params = sender.getParameters();
           if (!('encodings' in params) ||
               // Avoid being fooled by patched getParameters() below.
-              (params.encodings.length == 1 &&
-               Object.keys(params.encodings[0]).length == 0)) {
+              (params.encodings.length === 1 &&
+               Object.keys(params.encodings[0]).length === 0)) {
             params.encodings = initParameters.sendEncodings;
             sender.sendEncodings = initParameters.sendEncodings;
             this.setParametersPromises.push(sender.setParameters(params)


### PR DESCRIPTION
**Description**
Return at minimum an empty encoding from getParameters() when missing in Firefox.

**Purpose**
Improve getParameters() firefox shim just a tad more, so we can write JS with fewer hacks.