### PR TITLE
query browserDetails once and pass them

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -52,20 +52,20 @@ export function adapterFactory({window} = {}, options = {
       // Must be called before shimPeerConnection.
       commonShim.shimAddIceCandidateNullOrEmpty(window, browserDetails);
 
-      chromeShim.shimGetUserMedia(window);
-      chromeShim.shimMediaStream(window);
-      chromeShim.shimPeerConnection(window);
-      chromeShim.shimOnTrack(window);
-      chromeShim.shimAddTrackRemoveTrack(window);
-      chromeShim.shimGetSendersWithDtmf(window);
-      chromeShim.shimGetStats(window);
-      chromeShim.shimSenderReceiverGetStats(window);
-      chromeShim.fixNegotiationNeeded(window);
+      chromeShim.shimGetUserMedia(window, browserDetails);
+      chromeShim.shimMediaStream(window, browserDetails);
+      chromeShim.shimPeerConnection(window, browserDetails);
+      chromeShim.shimOnTrack(window, browserDetails);
+      chromeShim.shimAddTrackRemoveTrack(window, browserDetails);
+      chromeShim.shimGetSendersWithDtmf(window, browserDetails);
+      chromeShim.shimGetStats(window, browserDetails);
+      chromeShim.shimSenderReceiverGetStats(window, browserDetails);
+      chromeShim.fixNegotiationNeeded(window, browserDetails);
 
-      commonShim.shimRTCIceCandidate(window);
-      commonShim.shimConnectionState(window);
-      commonShim.shimMaxMessageSize(window);
-      commonShim.shimSendThrowTypeError(window);
+      commonShim.shimRTCIceCandidate(window, browserDetails);
+      commonShim.shimConnectionState(window, browserDetails);
+      commonShim.shimMaxMessageSize(window, browserDetails);
+      commonShim.shimSendThrowTypeError(window, browserDetails);
       commonShim.removeExtmapAllowMixed(window, browserDetails);
       break;
     case 'firefox':
@@ -81,22 +81,22 @@ export function adapterFactory({window} = {}, options = {
       // Must be called before shimPeerConnection.
       commonShim.shimAddIceCandidateNullOrEmpty(window, browserDetails);
 
-      firefoxShim.shimGetUserMedia(window);
-      firefoxShim.shimPeerConnection(window);
-      firefoxShim.shimOnTrack(window);
-      firefoxShim.shimRemoveStream(window);
-      firefoxShim.shimSenderGetStats(window);
-      firefoxShim.shimReceiverGetStats(window);
-      firefoxShim.shimRTCDataChannel(window);
-      firefoxShim.shimAddTransceiver(window);
-      firefoxShim.shimGetParameters(window);
-      firefoxShim.shimCreateOffer(window);
-      firefoxShim.shimCreateAnswer(window);
+      firefoxShim.shimGetUserMedia(window, browserDetails);
+      firefoxShim.shimPeerConnection(window, browserDetails);
+      firefoxShim.shimOnTrack(window, browserDetails);
+      firefoxShim.shimRemoveStream(window, browserDetails);
+      firefoxShim.shimSenderGetStats(window, browserDetails);
+      firefoxShim.shimReceiverGetStats(window, browserDetails);
+      firefoxShim.shimRTCDataChannel(window, browserDetails);
+      firefoxShim.shimAddTransceiver(window, browserDetails);
+      firefoxShim.shimGetParameters(window, browserDetails);
+      firefoxShim.shimCreateOffer(window, browserDetails);
+      firefoxShim.shimCreateAnswer(window, browserDetails);
 
-      commonShim.shimRTCIceCandidate(window);
-      commonShim.shimConnectionState(window);
-      commonShim.shimMaxMessageSize(window);
-      commonShim.shimSendThrowTypeError(window);
+      commonShim.shimRTCIceCandidate(window, browserDetails);
+      commonShim.shimConnectionState(window, browserDetails);
+      commonShim.shimMaxMessageSize(window, browserDetails);
+      commonShim.shimSendThrowTypeError(window, browserDetails);
       break;
     case 'edge':
       if (!edgeShim || !edgeShim.shimPeerConnection || !options.shimEdge) {
@@ -107,15 +107,15 @@ export function adapterFactory({window} = {}, options = {
       // Export to the adapter global object visible in the browser.
       adapter.browserShim = edgeShim;
 
-      edgeShim.shimGetUserMedia(window);
-      edgeShim.shimGetDisplayMedia(window);
-      edgeShim.shimPeerConnection(window);
-      edgeShim.shimReplaceTrack(window);
+      edgeShim.shimGetUserMedia(window, browserDetails);
+      edgeShim.shimGetDisplayMedia(window, browserDetails);
+      edgeShim.shimPeerConnection(window, browserDetails);
+      edgeShim.shimReplaceTrack(window, browserDetails);
 
       // the edge shim implements the full RTCIceCandidate object.
 
-      commonShim.shimMaxMessageSize(window);
-      commonShim.shimSendThrowTypeError(window);
+      commonShim.shimMaxMessageSize(window, browserDetails);
+      commonShim.shimSendThrowTypeError(window, browserDetails);
       break;
     case 'safari':
       if (!safariShim || !options.shimSafari) {
@@ -129,18 +129,18 @@ export function adapterFactory({window} = {}, options = {
       // Must be called before shimCallbackAPI.
       commonShim.shimAddIceCandidateNullOrEmpty(window, browserDetails);
 
-      safariShim.shimRTCIceServerUrls(window);
-      safariShim.shimCreateOfferLegacy(window);
-      safariShim.shimCallbacksAPI(window);
-      safariShim.shimLocalStreamsAPI(window);
-      safariShim.shimRemoteStreamsAPI(window);
-      safariShim.shimTrackEventTransceiver(window);
-      safariShim.shimGetUserMedia(window);
-      safariShim.shimAudioContext(window);
+      safariShim.shimRTCIceServerUrls(window, browserDetails);
+      safariShim.shimCreateOfferLegacy(window, browserDetails);
+      safariShim.shimCallbacksAPI(window, browserDetails);
+      safariShim.shimLocalStreamsAPI(window, browserDetails);
+      safariShim.shimRemoteStreamsAPI(window, browserDetails);
+      safariShim.shimTrackEventTransceiver(window, browserDetails);
+      safariShim.shimGetUserMedia(window, browserDetails);
+      safariShim.shimAudioContext(window, browserDetails);
 
-      commonShim.shimRTCIceCandidate(window);
-      commonShim.shimMaxMessageSize(window);
-      commonShim.shimSendThrowTypeError(window);
+      commonShim.shimRTCIceCandidate(window, browserDetails);
+      commonShim.shimMaxMessageSize(window, browserDetails);
+      commonShim.shimSendThrowTypeError(window, browserDetails);
       commonShim.removeExtmapAllowMixed(window, browserDetails);
       break;
     default:

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -436,11 +436,10 @@ export function shimAddTrackRemoveTrackWithNative(window) {
     };
 }
 
-export function shimAddTrackRemoveTrack(window) {
+export function shimAddTrackRemoveTrack(window, browserDetails) {
   if (!window.RTCPeerConnection) {
     return;
   }
-  const browserDetails = utils.detectBrowser(window);
   // shim addTrack and removeTrack.
   if (window.RTCPeerConnection.prototype.addTrack &&
       browserDetails.version >= 65) {
@@ -663,9 +662,7 @@ export function shimAddTrackRemoveTrack(window) {
     };
 }
 
-export function shimPeerConnection(window) {
-  const browserDetails = utils.detectBrowser(window);
-
+export function shimPeerConnection(window, browserDetails) {
   if (!window.RTCPeerConnection && window.webkitRTCPeerConnection) {
     // very basic support for old versions.
     window.RTCPeerConnection = window.webkitRTCPeerConnection;
@@ -691,8 +688,7 @@ export function shimPeerConnection(window) {
 }
 
 // Attempt to fix ONN in plan-b mode.
-export function fixNegotiationNeeded(window) {
-  const browserDetails = utils.detectBrowser(window);
+export function fixNegotiationNeeded(window, browserDetails) {
   utils.wrapPeerConnectionEvent(window, 'negotiationneeded', e => {
     const pc = e.target;
     if (browserDetails.version < 72 || (pc.getConfiguration &&

--- a/src/js/chrome/getusermedia.js
+++ b/src/js/chrome/getusermedia.js
@@ -10,14 +10,12 @@
 import * as utils from '../utils.js';
 const logging = utils.log;
 
-export function shimGetUserMedia(window) {
+export function shimGetUserMedia(window, browserDetails) {
   const navigator = window && window.navigator;
 
   if (!navigator.mediaDevices) {
     return;
   }
-
-  const browserDetails = utils.detectBrowser(window);
 
   const constraintsToChrome_ = function(c) {
     if (typeof c !== 'object' || c.mandatory || c.optional) {

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -63,11 +63,10 @@ export function shimRTCIceCandidate(window) {
   });
 }
 
-export function shimMaxMessageSize(window) {
+export function shimMaxMessageSize(window, browserDetails) {
   if (!window.RTCPeerConnection) {
     return;
   }
-  const browserDetails = utils.detectBrowser(window);
 
   if (!('sctp' in window.RTCPeerConnection.prototype)) {
     Object.defineProperty(window.RTCPeerConnection.prototype, 'sctp', {

--- a/src/js/edge/edge_shim.js
+++ b/src/js/edge/edge_shim.js
@@ -15,9 +15,7 @@ import shimRTCPeerConnection from 'rtcpeerconnection-shim';
 export {shimGetUserMedia} from './getusermedia';
 export {shimGetDisplayMedia} from './getdisplaymedia';
 
-export function shimPeerConnection(window) {
-  const browserDetails = utils.detectBrowser(window);
-
+export function shimPeerConnection(window, browserDetails) {
   if (window.RTCIceGatherer) {
     if (!window.RTCIceCandidate) {
       window.RTCIceCandidate = function RTCIceCandidate(args) {

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -24,9 +24,7 @@ export function shimOnTrack(window) {
   }
 }
 
-export function shimPeerConnection(window) {
-  const browserDetails = utils.detectBrowser(window);
-
+export function shimPeerConnection(window, browserDetails) {
   if (typeof window !== 'object' ||
       !(window.RTCPeerConnection || window.mozRTCPeerConnection)) {
     return; // probably media.peerconnection.enabled=false in about:config

--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -10,8 +10,7 @@
 
 import * as utils from '../utils';
 
-export function shimGetUserMedia(window) {
-  const browserDetails = utils.detectBrowser(window);
+export function shimGetUserMedia(window, browserDetails) {
   const navigator = window && window.navigator;
   const MediaStreamTrack = window && window.MediaStreamTrack;
 

--- a/test/e2e/maxMessageSize.js
+++ b/test/e2e/maxMessageSize.js
@@ -179,7 +179,7 @@ describe('maxMessageSize', () => {
     fakeWindow.RTCPeerConnection = function() {};
     fakeWindow.RTCPeerConnection.prototype.setRemoteDescription = () => {};
     fakeWindow.RTCPeerConnection.prototype.getConfiguration = () => ({});
-    window.adapter.commonShim.shimMaxMessageSize(fakeWindow);
+    window.adapter.commonShim.shimMaxMessageSize(fakeWindow, browserDetails);
 
     // Map specific browser versions to a test case.
     // You can use the following version comparators: '<=', '>=' and '=='.

--- a/test/unit/edge.js
+++ b/test/unit/edge.js
@@ -28,18 +28,18 @@ describe('Edge shim', () => {
         getDisplayMedia: sinon.stub,
       },
     };
-    shim.shimPeerConnection(window);
+    shim.shimPeerConnection(window, {});
   });
 
   it('creates window.RTCPeerConnection', () => {
     delete window.RTCPeerConnection;
-    shim.shimPeerConnection(window);
+    shim.shimPeerConnection(window, {});
     expect(window.RTCPeerConnection).not.to.equal(undefined);
   });
 
   it('overrides window.RTCPeerConnection if it exists', () => {
     window.RTCPeerConnection = true;
-    shim.shimPeerConnection(window);
+    shim.shimPeerConnection(window, {});
     expect(window.RTCPeerConnection).not.to.equal(true);
   });
 


### PR DESCRIPTION
which improves testability. No functional changes.