### PR TITLE
dont attempt to overwrite RTCSessionDescription.sdp

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -331,9 +331,19 @@ export function removeExtmapAllowMixed(window, browserDetails) {
   window.RTCPeerConnection.prototype.setRemoteDescription =
   function setRemoteDescription(desc) {
     if (desc && desc.sdp && desc.sdp.indexOf('\na=extmap-allow-mixed') !== -1) {
-      desc.sdp = desc.sdp.split('\n').filter((line) => {
+      const sdp = desc.sdp.split('\n').filter((line) => {
         return line.trim() !== 'a=extmap-allow-mixed';
       }).join('\n');
+      // Safari enforces read-only-ness of RTCSessionDescription fields.
+      if (window.RTCSessionDescription &&
+          desc instanceof window.RTCSessionDescription) {
+        arguments[0] = new window.RTCSessionDescription({
+          type: desc.type,
+          sdp,
+        });
+      } else {
+        desc.sdp = sdp;
+      }
     }
     return nativeSRD.apply(this, arguments);
   };


### PR DESCRIPTION
follow-up on #1042. Shouldn't be necessary in new Safari versions but see [here](https://bugs.chromium.org/p/chromium/issues/detail?id=1186456&)