### PR TITLE
firefox: fix detection on insecure contexts

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -160,7 +160,7 @@ export function detectBrowser(window) {
 
   const {navigator} = window;
 
-  if (navigator.mozGetUserMedia) { // Firefox.
+  if (navigator.mozGetUserMedia || window.mozRTCPeerConnection) { // Firefox.
     result.browser = 'firefox';
     result.version = extractVersion(navigator.userAgent,
         /Firefox\/(\d+)\./, 1);


### PR DESCRIPTION
@jan-ivar: on insecure contexts mozGetUserMedia isn't defined but mozRTCPeerConnection is :-p