### PR TITLE
safari: fix transceiver direction in createOffer

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -311,7 +311,7 @@ export function shimCreateOfferLegacy(window) {
           }
         } else if (offerOptions.offerToReceiveAudio === true &&
             !audioTransceiver) {
-          this.addTransceiver('audio');
+          this.addTransceiver('audio', {direction: 'recvonly'});
         }
 
         if (typeof offerOptions.offerToReceiveVideo !== 'undefined') {
@@ -337,7 +337,7 @@ export function shimCreateOfferLegacy(window) {
           }
         } else if (offerOptions.offerToReceiveVideo === true &&
             !videoTransceiver) {
-          this.addTransceiver('video');
+          this.addTransceiver('video', {direction: 'recvonly'});
         }
       }
       return origCreateOffer.apply(this, arguments);


### PR DESCRIPTION
When there is no transceiver, it is created with the default "sendrecv" direction.
From the WebRTC spec, it must be "recvonly".
https://w3c.github.io/webrtc-pc/#legacy-configuration-extensions

**Description**


**Purpose**
