### PR TITLE
chrome: add naive selectAudioOutput shim

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -63,6 +63,7 @@ export function adapterFactory({window} = {}, options = {
       chromeShim.shimGetStats(window, browserDetails);
       chromeShim.shimSenderReceiverGetStats(window, browserDetails);
       chromeShim.fixNegotiationNeeded(window, browserDetails);
+      chromeShim.shimSelectAudioOutput(window, browserDetails);
 
       commonShim.shimRTCIceCandidate(window, browserDetails);
       commonShim.shimConnectionState(window, browserDetails);

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -11,6 +11,7 @@ import * as utils from '../utils.js';
 
 export {shimGetUserMedia} from './getusermedia';
 export {shimGetDisplayMedia} from './getdisplaymedia';
+export {shimSelectAudioOutput} from './selectaudiooutput';
 
 export function shimMediaStream(window) {
   window.MediaStream = window.MediaStream || window.webkitMediaStream;

--- a/src/js/chrome/selectaudiooutput.js
+++ b/src/js/chrome/selectaudiooutput.js
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2022 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+export function shimSelectAudioOutput(window) {
+  // Polyfillying only makes sense when setSinkId is available
+  // and the function is not already there.
+  if (!('HTMLMediaElement' in window)) {
+    return;
+  }
+  if (!('setSinkId' in window.HTMLMediaElement.prototype)) {
+    return;
+  }
+  if (!(window.navigator && window.navigator.mediaDevices)) {
+    return;
+  }
+  if (!window.navigator.mediaDevices.enumerateDevices) {
+    return;
+  }
+  if (window.navigator.mediaDevices.selectAudioOutput) {
+    return;
+  }
+  window.navigator.mediaDevices.selectAudioOutput = () => {
+    return window.navigator.mediaDevices.enumerateDevices()
+      .then(devices => devices.filter(d => d.kind === 'audiooutput'));
+  };
+}

--- a/test/e2e/selectAudioOutput.js
+++ b/test/e2e/selectAudioOutput.js
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2022 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+describe('selectAudioOutput', () => {
+  it('returns a list of audio output devices', () => {
+    return navigator.mediaDevices.selectAudioOutput()
+      .then(devices => {
+        expect(devices).to.be.an('array');
+        devices.forEach(d => {
+          expect(d.kind).to.equal('audiooutput');
+        });
+      });
+  });
+});


### PR DESCRIPTION
based on enumerateDevices. This allows apps to somewhat use
getUserMedia already to use selectAudioOutput (but will not show any prompt).
Note that this does not (yet) modify enumerateDevices output.