### PR TITLE
Shims/fixes for `RTCDataChannel.binaryType`

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -70,6 +70,7 @@ export function adapterFactory({window} = {}, options = {
       commonShim.shimMaxMessageSize(window, browserDetails);
       commonShim.shimSendThrowTypeError(window, browserDetails);
       commonShim.removeExtmapAllowMixed(window, browserDetails);
+      commonShim.fixBinaryTypeDefault(window, browserDetails);
       break;
     case 'firefox':
       if (!firefoxShim || !firefoxShim.shimPeerConnection ||
@@ -128,6 +129,7 @@ export function adapterFactory({window} = {}, options = {
       commonShim.shimMaxMessageSize(window, browserDetails);
       commonShim.shimSendThrowTypeError(window, browserDetails);
       commonShim.removeExtmapAllowMixed(window, browserDetails);
+      commonShim.fixBinaryTypeDefault(window, browserDetails);
       break;
     default:
       logging('Unsupported browser!');

--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -62,6 +62,7 @@ export function adapterFactory({window} = {}, options = {
       chromeShim.shimGetSendersWithDtmf(window, browserDetails);
       chromeShim.shimGetStats(window, browserDetails);
       chromeShim.shimSenderReceiverGetStats(window, browserDetails);
+      chromeShim.shimBinaryTypeBlob(window, browserDetails);
       chromeShim.fixNegotiationNeeded(window, browserDetails);
 
       commonShim.shimRTCIceCandidate(window, browserDetails);

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -52,7 +52,7 @@ export function shimRTCIceCandidate(window) {
 
   // Hook up the augmented candidate in onicecandidate and
   // addEventListener('icecandidate', ...)
-  utils.wrapPeerConnectionEvent(window, 'icecandidate', e => {
+  utils.wrapEvent(window.RTCPeerConnection, 'icecandidate', e => {
     if (e.candidate) {
       Object.defineProperty(e, 'candidate', {
         value: new window.RTCIceCandidate(e.candidate),
@@ -246,7 +246,7 @@ export function shimSendThrowTypeError(window) {
       wrapDcSend(dataChannel, this);
       return dataChannel;
     };
-  utils.wrapPeerConnectionEvent(window, 'datachannel', e => {
+  utils.wrapEvent(window.RTCPeerConnection, 'datachannel', e => {
     wrapDcSend(e.channel, e.target);
     return e;
   });

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -349,6 +349,19 @@ export function removeExtmapAllowMixed(window, browserDetails) {
   };
 }
 
+export function fixBinaryTypeDefault(window) {
+  // Changes the default value of `RTCDataChannel.binaryType`
+  // to be 'blob' as per the spec.
+  const origCreateDataChannel =
+    window.RTCPeerConnection.prototype.createDataChannel;
+  window.RTCPeerConnection.prototype.createDataChannel =
+    function createDataChannel() {
+      const channel = origCreateDataChannel.apply(this, arguments);
+      channel.binaryType = 'blob';
+      return channel;
+    };
+}
+
 export function shimAddIceCandidateNullOrEmpty(window, browserDetails) {
   // Support for addIceCandidate(null or undefined)
   // as well as addIceCandidate({candidate: "", ...})

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -134,7 +134,7 @@ export function shimReceiverGetStats(window) {
       return receivers;
     };
   }
-  utils.wrapPeerConnectionEvent(window, 'track', e => {
+  utils.wrapEvent(window.RTCPeerConnection, 'track', e => {
     e.receiver._pc = e.srcElement;
     return e;
   });

--- a/test/e2e/binaryType.js
+++ b/test/e2e/binaryType.js
@@ -28,7 +28,6 @@ describe('RTCDataChannel.binaryType', () => {
   it('can be changed to \'arraybuffer\' and back', () => {
     const channel = pc.createDataChannel('channel');
 
-    expect(channel.binaryType).to.equal('blob');
     channel.binaryType = 'arraybuffer';
     expect(channel.binaryType).to.equal('arraybuffer');
     channel.binaryType = 'blob';
@@ -63,15 +62,8 @@ describe('RTCDataChannel.binaryType', () => {
       .then(() => pc.setRemoteDescription(pc2.localDescription))
       // Then wait for our channels to open.
       .then(() => channelsOpen)
-      // Test that in the initial 'blob' state, the messages are `Blob`s
-      .then(() => new Promise(resolve => {
-        expect(channel1.binaryType).to.equal('blob');
-        channel1.onmessage = ev => resolve(ev.data);
-        channel2.send(new Uint8Array([1, 2, 3, 4]));
-      }))
-      .then(data => expect(data).to.be.instanceOf(Blob))
-      // Then test that when we change `binaryType` to 'arraybuffer',
-      // the messages are `ArrayBuffer`s
+      // Test that when we set `binaryType` to 'arraybuffer',
+      // the messages are `ArrayBuffer`s.
       .then(() => new Promise(resolve => {
         channel1.binaryType = 'arraybuffer';
         expect(channel1.binaryType).to.equal('arraybuffer');
@@ -79,7 +71,8 @@ describe('RTCDataChannel.binaryType', () => {
         channel2.send(new Uint8Array([1, 2, 3, 4]));
       }))
       .then(data => expect(data).to.be.instanceOf(ArrayBuffer))
-      // Then change it back to 'blob' and test that still works
+      // Test that when we set `binaryType` to 'blob',
+      // the messages are `Blob`s.
       .then(() => new Promise(resolve => {
         channel1.binaryType = 'blob';
         expect(channel1.binaryType).to.equal('blob');

--- a/test/e2e/binaryType.js
+++ b/test/e2e/binaryType.js
@@ -47,7 +47,7 @@ describe('RTCDataChannel.binaryType', () => {
     const channelsOpen = new Promise(resolve => {
       pc2.ondatachannel = ev => {
         channel2 = ev.channel;
-        resolve();
+        channel2.onopen = () => resolve();
       };
       // Create the channel after setting the listener for it
       // to guarantee that it gets called.

--- a/test/e2e/binaryType.js
+++ b/test/e2e/binaryType.js
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2017 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+ /* eslint-env node */
+'use strict';
+
+describe('RTCDataChannel.binaryType', () => {
+  let pc;
+  beforeEach(() => {
+    pc = new RTCPeerConnection();
+  });
+  afterEach(() => {
+    if (pc.signalingState !== 'closed') {
+      pc.close();
+    }
+  });
+
+  it('is \'blob\' by default', () => {
+    const channel = pc.createDataChannel('channel');
+
+    expect(channel.binaryType).to.equal('blob');
+  });
+
+  it('can be changed to \'arraybuffer\' and back', () => {
+    const channel = pc.createDataChannel('channel');
+
+    expect(channel.binaryType).to.equal('blob');
+    channel.binaryType = 'arraybuffer';
+    expect(channel.binaryType).to.equal('arraybuffer');
+    channel.binaryType = 'blob';
+    expect(channel.binaryType).to.equal('blob');
+  });
+
+  it('changes the type of `MessageEvent.data`', () => {
+    const pc2 = new RTCPeerConnection();
+
+    pc.onicecandidate = ev => pc2.addIceCandidate(ev.candidate);
+    pc2.onicecandidate = ev => pc.addIceCandidate(ev.candidate);
+
+    let channel1;
+    let channel2;
+
+    const channelsOpen = new Promise(resolve => {
+      pc2.ondatachannel = ev => {
+        channel2 = ev.channel;
+        resolve();
+      };
+      // Create the channel after setting the listener for it
+      // to guarantee that it gets called.
+      channel1 = pc.createDataChannel('channel');
+    });
+
+    // Set up a connection
+    return pc.createOffer()
+      .then(offer => pc.setLocalDescription(offer))
+      .then(() => pc2.setRemoteDescription(pc.localDescription))
+      .then(() => pc2.createAnswer())
+      .then(answer => pc2.setLocalDescription(answer))
+      .then(() => pc.setRemoteDescription(pc2.localDescription))
+      // Then wait for our channels to open.
+      .then(() => channelsOpen)
+      // Test that in the initial 'blob' state, the messages are `Blob`s
+      .then(() => new Promise(resolve => {
+        expect(channel1.binaryType).to.equal('blob');
+        channel1.onmessage = ev => resolve(ev.data);
+        channel2.send(new Uint8Array([1, 2, 3, 4]));
+      }))
+      .then(data => expect(data).to.be.instanceOf(Blob))
+      // Then test that when we change `binaryType` to 'arraybuffer',
+      // the messages are `ArrayBuffer`s
+      .then(() => new Promise(resolve => {
+        channel1.binaryType = 'arraybuffer';
+        expect(channel1.binaryType).to.equal('arraybuffer');
+        channel1.onmessage = ev => resolve(ev.data);
+        channel2.send(new Uint8Array([1, 2, 3, 4]));
+      }))
+      .then(data => expect(data).to.be.instanceOf(ArrayBuffer))
+      // Then change it back to 'blob' and test that still works
+      .then(() => new Promise(resolve => {
+        channel1.binaryType = 'blob';
+        expect(channel1.binaryType).to.equal('blob');
+        channel1.onmessage = ev => resolve(ev.data);
+        channel2.send(new Uint8Array([1, 2, 3, 4]));
+      }))
+      .then(data => expect(data).to.be.instanceOf(Blob));
+  });
+
+  it('throws when you change it to a bogus value', () => {
+    const channel = pc.createDataChannel('channel');
+
+    expect(() => channel.binaryType = 'aughadsfiughadsfoiughaoiudf').to.throw();
+  });
+});

--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -1,3 +1,4 @@
+ERR RTCDataChannel.binaryType throws when you change it to a bogus value AssertionError
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
 ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -1,3 +1,4 @@
+ERR RTCDataChannel.binaryType throws when you change it to a bogus value AssertionError
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
 ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -1,3 +1,4 @@
+ERR RTCDataChannel.binaryType throws when you change it to a bogus value AssertionError
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
 ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -1,3 +1,4 @@
+ERR RTCDataChannel.binaryType throws when you change it to a bogus value AssertionError
 ERR navigator.mediaDevices enumerateDevices returns some audiooutput devices AssertionError
 ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
 ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError


### PR DESCRIPTION
**Description**
- Shims `RTCDataChannel.binaryType: 'blob'` in Chrome (which doesn't support it)
- Makes 'blob' the default value for `RTCDataChannel.binaryType` in Chrome and Safari, as the spec states it should be.

**Purpose**
Make `RTCDataChannel.binaryType` work consistently across browsers.