### PR TITLE
firefox: dont attempt to shim getUserMedia if mediaDevices is not defined

### DIFF
--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -14,6 +14,10 @@ export function shimGetUserMedia(window, browserDetails) {
   const navigator = window && window.navigator;
   const MediaStreamTrack = window && window.MediaStreamTrack;
 
+  if (!navigator.mediaDevices) {
+    return;
+  }
+
   navigator.getUserMedia = function(constraints, onSuccess, onError) {
     // Replace Firefox 44+'s deprecation warning with unprefixed version.
     utils.deprecated('navigator.getUserMedia',


### PR DESCRIPTION
since this can't work. Tentative fix for #1022