### PR TITLE
Extract Safari version instead of WebKit version

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -353,7 +353,7 @@ export function removeExtmapAllowMixed(window, browserDetails) {
   if (browserDetails.browser === 'chrome' && browserDetails.version >= 71) {
     return;
   }
-  if (browserDetails.browser === 'safari' && browserDetails.version >= 605) {
+  if (browserDetails.browser === 'safari' && browserDetails.version >= 13.1) {
     return;
   }
   const nativeSRD = window.RTCPeerConnection.prototype.setRemoteDescription;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -177,7 +177,7 @@ export function detectBrowser(window) {
       navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) { // Safari.
     result.browser = 'safari';
     result.version = extractVersion(navigator.userAgent,
-      /version\/(\d+(\.?\d))/i, 1);
+      /version\/(\d+(\.?\d+))/i, 1);
     result.supportsUnifiedPlan = window.RTCRtpTransceiver &&
         'currentDirection' in window.RTCRtpTransceiver.prototype;
   } else { // Default fallthrough: not supported.

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,7 +21,11 @@ let deprecationWarnings_ = true;
  */
 export function extractVersion(uastring, expr, pos) {
   const match = uastring.match(expr);
-  return match && match.length >= pos && parseInt(match[pos], 10);
+  if (match === null) {
+    return null;
+  }
+  const versionParts = match[pos].split('.').slice(0, 2);
+  return match && match.length >= pos && parseFloat(versionParts.join('.'), 10);
 }
 
 // Wraps the peerconnection event eventNameToWrap in a function
@@ -177,7 +181,8 @@ export function detectBrowser(window) {
       navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) { // Safari.
     result.browser = 'safari';
     result.version = extractVersion(navigator.userAgent,
-      /AppleWebKit\/(\d+)\./, 1);
+      /version\/(\d+(\.?_?\d+)+)/i, 1);
+    console.log(result.version);
     result.supportsUnifiedPlan = window.RTCRtpTransceiver &&
         'currentDirection' in window.RTCRtpTransceiver.prototype;
   } else { // Default fallthrough: not supported.

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -21,11 +21,7 @@ let deprecationWarnings_ = true;
  */
 export function extractVersion(uastring, expr, pos) {
   const match = uastring.match(expr);
-  if (match === null) {
-    return null;
-  }
-  const versionParts = match[pos].split('.').slice(0, 2);
-  return match && match.length >= pos && parseFloat(versionParts.join('.'), 10);
+  return match && match.length >= pos && parseFloat(match[pos], 10);
 }
 
 // Wraps the peerconnection event eventNameToWrap in a function
@@ -181,8 +177,7 @@ export function detectBrowser(window) {
       navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) { // Safari.
     result.browser = 'safari';
     result.version = extractVersion(navigator.userAgent,
-      /version\/(\d+(\.?_?\d+)+)/i, 1);
-    console.log(result.version);
+      /version\/(\d+(\.?\d))/i, 1);
     result.supportsUnifiedPlan = window.RTCRtpTransceiver &&
         'currentDirection' in window.RTCRtpTransceiver.prototype;
   } else { // Default fallthrough: not supported.

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -177,7 +177,7 @@ export function detectBrowser(window) {
       navigator.userAgent.match(/AppleWebKit\/(\d+)\./)) { // Safari.
     result.browser = 'safari';
     result.version = extractVersion(navigator.userAgent,
-      /version\/(\d+(\.?\d+))/i, 1);
+      /Version\/(\d+(\.?\d+))/i, 1);
     result.supportsUnifiedPlan = window.RTCRtpTransceiver &&
         'currentDirection' in window.RTCRtpTransceiver.prototype;
   } else { // Default fallthrough: not supported.

--- a/test/unit/detectBrowser.js
+++ b/test/unit/detectBrowser.js
@@ -60,6 +60,6 @@ describe('detectBrowser', () => {
 
     const browserDetails = detectBrowser(window);
     expect(browserDetails.browser).to.equal('safari');
-    expect(browserDetails.version).to.equal(604);
+    expect(browserDetails.version).to.equal(10.2);
   });
 });

--- a/test/unit/extmap-allow-mixed.js
+++ b/test/unit/extmap-allow-mixed.js
@@ -70,11 +70,11 @@ describe('removal of extmap-allow-mixed', () => {
       window.RTCPeerConnection.prototype.setRemoteDescription = function() {
         return origSetRemoteDescription.apply(this, arguments);
       };
-      browserDetails = {browser: 'safari', version: '605'};
+      browserDetails = {browser: 'safari', version: 13.1};
     });
 
-    it('does not remove the extmap-allow-mixed line after 605', () => {
-      browserDetails.version = 605;
+    it('does not remove the extmap-allow-mixed line after 13.1', () => {
+      browserDetails.version = 13.1;
       shim.removeExtmapAllowMixed(window, browserDetails);
 
       const pc = new window.RTCPeerConnection();
@@ -83,8 +83,8 @@ describe('removal of extmap-allow-mixed', () => {
         .to.equal('\n' + sdp);
     });
 
-    it('does remove the extmap-allow-mixed line before 605', () => {
-      browserDetails.version = 604;
+    it('does remove the extmap-allow-mixed line before 13.1', () => {
+      browserDetails.version = 13.0;
       shim.removeExtmapAllowMixed(window, browserDetails);
 
       const pc = new window.RTCPeerConnection();

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -117,10 +117,17 @@ describe('extractVersion', () => {
 
   describe('Safari regular expression', () => {
     const expr = /version\/(\d+(\.?_?\d+)+)/i;
-    it('matches the webkit version', () => {
+    it('matches the Safari version', () => {
       ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
       expect(extractVersion(ua, expr, 1)).to.equal(10.2);
+    });
+
+    it('drops patch version numbers', () => {
+      ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) ' +
+          'AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0.4 ' +
+          'Mobile/11D167 Safari/9537.53';
+      expect(extractVersion(ua, expr, 1)).to.equal(7.0);
     });
 
     it('matches the iphone simulator', () => {

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -116,7 +116,7 @@ describe('extractVersion', () => {
   });
 
   describe('Safari regular expression', () => {
-    const expr = /version\/(\d+(\.?\d+))/i;
+    const expr = /Version\/(\d+(\.?\d+))/i;
     it('matches the Safari version', () => {
       ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -116,7 +116,7 @@ describe('extractVersion', () => {
   });
 
   describe('Safari regular expression', () => {
-    const expr = /version\/(\d+(\.?_?\d+)+)/i;
+    const expr = /version\/(\d+(\.?\d))/i;
     it('matches the Safari version', () => {
       ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -116,30 +116,30 @@ describe('extractVersion', () => {
   });
 
   describe('Safari regular expression', () => {
-    const expr = /AppleWebKit\/(\d+)/;
+    const expr = /version\/(\d+(\.?_?\d+)+)/i;
     it('matches the webkit version', () => {
       ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';
-      expect(extractVersion(ua, expr, 1)).to.equal(604);
+      expect(extractVersion(ua, expr, 1)).to.equal(10.2);
     });
 
     it('matches the iphone simulator', () => {
       ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) ' +
           'AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 ' +
           'Mobile/12A4345d Safari/600.1.4';
-      expect(extractVersion(ua, expr, 1)).to.equal(600);
+      expect(extractVersion(ua, expr, 1)).to.equal(8.0);
     });
 
-    it('matches Chrome (by design, do not use for Chrome)', () => {
+    it('does not match Chrome', () => {
       ua = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like ' +
           'Gecko) Chrome/45.0.2454.101 Safari/537.36';
-      expect(extractVersion(ua, expr, 1)).to.equal(537);
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
     });
 
-    it('matches Edge (by design, do not use for Edge', () => {
+    it('does not match Edge', () => {
       ua = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
           '(KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547';
-      expect(extractVersion(ua, expr, 1)).to.equal(537);
+      expect(extractVersion(ua, expr, 1)).to.equal(null);
     });
 
     it('does not match Firefox', () => {

--- a/test/unit/extractVersion.js
+++ b/test/unit/extractVersion.js
@@ -116,7 +116,7 @@ describe('extractVersion', () => {
   });
 
   describe('Safari regular expression', () => {
-    const expr = /version\/(\d+(\.?\d))/i;
+    const expr = /version\/(\d+(\.?\d+))/i;
     it('matches the Safari version', () => {
       ua = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) ' +
           'AppleWebKit/604.1.6 (KHTML, like Gecko) Version/10.2 Safari/604.1.6';


### PR DESCRIPTION
**Description**
This PR changes the version extraction for Safari to look at the actual Safari version instead of the WebKit version.
Minor versions (e.g. `10.3`) get parsed as float in order to keep straight forward version comparison as before.
In case there would be a patch version defined in the ua string (e.g. `10.3.4`) the patch version gets dropped. 

The oldest Safari versions I could find still work with that approach:
- macOS Safari 4.0 - `Mozilla/5.0 (Macintosh; U; Intel Mac 05 X 10_6_8; en-us) ApplewebKit/531.22.7 (KHTML, like Gecko) Version/4.0.5 Safari/531.22.7`
- iOS Safari 7.0 - `Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D167 Safari/9537.53`

**Purpose**
fixes #1082

Safari has stopped updating WebKit versions in the user agent string. E.g. Safari 16.3 still shows `AppleWebKit/605.1.15`. 

