### PR TITLE
Shim RTCRtpScriptTransform.

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -63,6 +63,7 @@ export function adapterFactory({window} = {}, options = {
       chromeShim.shimGetStats(window, browserDetails);
       chromeShim.shimSenderReceiverGetStats(window, browserDetails);
       chromeShim.fixNegotiationNeeded(window, browserDetails);
+      chromeShim.shimRTCRtpScriptTransform(window, browserDetails);
 
       commonShim.shimRTCIceCandidate(window, browserDetails);
       commonShim.shimRTCIceCandidateRelayProtocol(window, browserDetails);

--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -712,16 +712,18 @@ export function shimRTCRtpScriptTransform(window) {
         this._transfer = transfer;
       }
     };
-    const property = {
+    const prop = {
       get() {
         return this._transform || null;
       },
       set(transform) {
         if (transform && !(transform instanceof window.RTCRtpScriptTransform)) {
-          throw new TypeError("expected window.RTCRtpScriptTransform");
+          throw new TypeError('expected window.RTCRtpScriptTransform');
         }
         this._transform = transform || null;
-        if (!transform) return;
+        if (!transform) {
+          return;
+        }
         const {readable, writable} = this.createEncodedStreams();
         transform._worker.postMessage({
           rtctransform: {
@@ -730,7 +732,7 @@ export function shimRTCRtpScriptTransform(window) {
         }, [readable, writable, ...(transform._transfer || [])]);
       }
     };
-    Object.defineProperty(window.RTCRtpSender.prototype, 'transform', property);
-    Object.defineProperty(window.RTCRtpReceiver.prototype, 'transform', property);
+    Object.defineProperty(window.RTCRtpSender.prototype, 'transform', prop);
+    Object.defineProperty(window.RTCRtpReceiver.prototype, 'transform', prop);
   }
 }


### PR DESCRIPTION
**Description**

Add a chrome shim for RTCRtpScriptTransform.

**Purpose**

Help web developers write WebRTC encoded-transform code to spec that works across browsers.

Working example: https://jan-ivar.github.io/samples/src/content/insertable-streams/video-analyzer/ (uses temp shim)

**Usage**

Making the shim work requires adding the following line in workers:
```js
// accept shimming
self.onmessage = ({data}) => data.rtctransform && self.onrtctransform({transformer: data.rtctransform});
```
