### PR TITLE
skip getLocalЅtreams/removeTrack assertions in Firefox

### DIFF
--- a/test/e2e/expectations/firefox-beta
+++ b/test/e2e/expectations/firefox-beta
@@ -1,2 +1,2 @@
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
-ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
+SKIP removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
+SKIP removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain

--- a/test/e2e/expectations/firefox-esr
+++ b/test/e2e/expectations/firefox-esr
@@ -1,2 +1,2 @@
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
-ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
+SKIP removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
+SKIP removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain

--- a/test/e2e/expectations/firefox-nightly
+++ b/test/e2e/expectations/firefox-nightly
@@ -1,2 +1,2 @@
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
-ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
+SKIP removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
+SKIP removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain

--- a/test/e2e/expectations/firefox-stable
+++ b/test/e2e/expectations/firefox-stable
@@ -1,2 +1,2 @@
-ERR removeTrack after addStream for an audio/video track after removing all tracks no local streams remain AssertionError
-ERR removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain AssertionError
+SKIP removeTrack after addStream for an audio/video track after removing all tracks no local streams remain
+SKIP removeTrack after addTrack for an audio/video track after removing all tracks no local streams remain

--- a/test/e2e/removeTrack.js
+++ b/test/e2e/removeTrack.js
@@ -114,7 +114,10 @@ describe('removeTrack', () => {
           expect(sendersWithTrack).to.have.length(0);
         });
 
-        it('no local streams remain', () => {
+        it('no local streams remain', function() {
+          if (window.adapter.browserDetails.browser === 'firefox') {
+            this.skip();
+          }
           const senders = pc.getSenders();
           senders.forEach(sender => pc.removeTrack(sender));
           expect(pc.getLocalStreams()).to.have.length(0);


### PR DESCRIPTION
since getLocalStreams is legacy and should not be used anymore
