### PR TITLE
use stricter guards for some ancient polyfills

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -15,7 +15,11 @@ export function shimMediaStream(window) {
   window.MediaStream = window.MediaStream || window.webkitMediaStream;
 }
 
-export function shimOnTrack(window) {
+export function shimOnTrack(window, browserDetails) {
+  if (browserDetails.version > 102) {
+    // Unified plan is supported so no need to do anything.
+    return;
+  }
   if (typeof window === 'object' && window.RTCPeerConnection && !('ontrack' in
       window.RTCPeerConnection.prototype)) {
     Object.defineProperty(window.RTCPeerConnection.prototype, 'ontrack', {
@@ -621,6 +625,10 @@ export function shimPeerConnection(window, browserDetails) {
 
 // Attempt to fix ONN in plan-b mode.
 export function fixNegotiationNeeded(window, browserDetails) {
+  if (browserDetails.version > 102) {
+    // Plan-B is no longer supported.
+    return;
+  }
   utils.wrapPeerConnectionEvent(window, 'negotiationneeded', e => {
     const pc = e.target;
     if (browserDetails.version < 72 || (pc.getConfiguration &&

--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -244,15 +244,22 @@ export function shimMaxMessageSize(window, browserDetails) {
     };
 }
 
-export function shimSendThrowTypeError(window) {
+export function shimSendThrowTypeError(window, browserDetails) {
   if (!(window.RTCPeerConnection &&
       'createDataChannel' in window.RTCPeerConnection.prototype)) {
+    return;
+  }
+  if (browserDetails.browser === 'chrome' && browserDetails.version > 149) {
+    // Fixed by https://issues.chromium.org/issues/490588131
     return;
   }
 
   // Note: Although Firefox >= 57 has a native implementation, the maximum
   //       message size can be reset for all data channels at a later stage.
   //       See: https://bugzilla.mozilla.org/show_bug.cgi?id=1426831
+  if (browserDetails.browser === 'firefox' && browserDetails.version > 60) {
+    return;
+  }
 
   function wrapDcSend(dc, pc) {
     const origDataChannelSend = dc.send;

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -31,8 +31,15 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
   if (!window.RTCPeerConnection) {
     return;
   }
+  const addEventListener = Object.getOwnPropertyDescriptor(
+    EventTarget.prototype, 'addEventListener');
+  if (!addEventListener.writable) {
+    log('Unable to polyfill events');
+    return;
+  }
   const proto = window.RTCPeerConnection.prototype;
   const nativeAddEventListener = proto.addEventListener;
+
   proto.addEventListener = function(nativeEventName, cb) {
     if (nativeEventName !== eventNameToWrap) {
       return nativeAddEventListener.apply(this, arguments);

--- a/test/testpage.html
+++ b/test/testpage.html
@@ -5,6 +5,11 @@
 </head>
 <body>
 <h1>Test page for adapter.js</h1>
+<script>
+Object.defineProperty(EventTarget.prototype, 'addEventListener', {
+  writable: false
+});
+</script>
 <script src="../out/adapter.js"></script>
 The browser is: <span id="browser"></span>
 <br>


### PR DESCRIPTION
use stricter guards for some ancient polyfills

* shimOnTrack which is no longer useful in unified-plan which is the only remaining mode as of M102.
* fixNegotiationNeeded which is working in unified-plan
* shimSendThrowTypeError which is no longer required in Firefox60+. Still required in Chrome and Safari as of WebRTC M148, fixed in M149.

Also do not override the event listener if it is not writable which avoids (but does not fix) #1177
