### PR TITLE
firefox: do not throw when calling getStats on a closed peerconnection

### DIFF
--- a/src/js/adapter_factory.js
+++ b/src/js/adapter_factory.js
@@ -86,6 +86,7 @@ export function adapterFactory({window} = {}, options = {
 
       firefoxShim.shimGetUserMedia(window, browserDetails);
       firefoxShim.shimPeerConnection(window, browserDetails);
+      firefoxShim.shimGetStats(window, browserDetails);
       firefoxShim.shimOnTrack(window, browserDetails);
       firefoxShim.shimRemoveStream(window, browserDetails);
       firefoxShim.shimSenderGetStats(window, browserDetails);

--- a/src/js/firefox/firefox_shim.js
+++ b/src/js/firefox/firefox_shim.js
@@ -48,6 +48,17 @@ export function shimPeerConnection(window, browserDetails) {
         window.RTCPeerConnection.prototype[method] = methodObj[method];
       });
   }
+}
+
+export function shimGetStats(window, browserDetails) {
+  if (typeof window !== 'object' ||
+      !(window.RTCPeerConnection || window.mozRTCPeerConnection)) {
+    return; // probably media.peerconnection.enabled=false in about:config
+  }
+  if (browserDetails.version >= 151) {
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1056433
+    return;
+  }
 
   const modernStatsTypes = {
     inboundrtp: 'inbound-rtp',
@@ -60,6 +71,10 @@ export function shimPeerConnection(window, browserDetails) {
   const nativeGetStats = window.RTCPeerConnection.prototype.getStats;
   window.RTCPeerConnection.prototype.getStats = function getStats() {
     const [selector, onSucc, onErr] = arguments;
+    if (this.signalingState === 'closed') {
+      // No longer required in FF151+
+      return Promise.resolve(new Map());
+    }
     return nativeGetStats.apply(this, [selector || null])
       .then(stats => {
         if (browserDetails.version < 53 && !onSucc) {

--- a/test/e2e/getStats.js
+++ b/test/e2e/getStats.js
@@ -30,4 +30,8 @@ describe('getStats', () => {
         expect(result).to.have.property('forEach');
       });
   });
+  it('resolves on a closed peerconnection without throwing', () => {
+    pc.close();
+    return pc.getStats();
+  });
 });


### PR DESCRIPTION
which is fixed in Firefox 151+, see
  https://bugzilla.mozilla.org/show_bug.cgi?id=1056433

Fixes #1179
