### PR TITLE
chrome: guard sender/receiver getStats polyfill

### DIFF
--- a/src/js/chrome/chrome_shim.js
+++ b/src/js/chrome/chrome_shim.js
@@ -191,7 +191,10 @@ export function shimGetSendersWithDtmf(window) {
   }
 }
 
-export function shimSenderReceiverGetStats(window) {
+export function shimSenderReceiverGetStats(window, browserDetails) {
+  if (browserDetails.version >= 67) {
+    return;
+  }
   if (!(typeof window === 'object' && window.RTCPeerConnection &&
       window.RTCRtpSender && window.RTCRtpReceiver)) {
     return;


### PR DESCRIPTION
which is obsolete as of M76:
  https://chromium-review.googlesource.com/c/chromium/src/+/997554
  https://chromium-review.googlesource.com/c/chromium/src/+/978128

(see #1182)
