### PR TITLE
firefox: guard max message size shim on version too

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -100,6 +100,11 @@ export function shimMaxMessageSize(window, browserDetails) {
     // Unified plan is supported so no need to do anything.
     return;
   }
+  if (browserDetails.browser === 'firefox' && browserDetails.version >= 113) {
+    // Native RTCSctpTransport, see
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1278299
+    return;
+  }
 
   if (!('sctp' in window.RTCPeerConnection.prototype)) {
     Object.defineProperty(window.RTCPeerConnection.prototype, 'sctp', {


### PR DESCRIPTION
FF113, https://bugzilla.mozilla.org/show_bug.cgi?id=1278299

see also #1182