### PR TITLE
firefox: dont attempt to shim getUserMedia if mediaDevices is not defined

### DIFF
--- a/src/js/firefox/getusermedia.js
+++ b/src/js/firefox/getusermedia.js
@@ -12,6 +12,9 @@ import * as utils from '../utils';
 
 export function shimGetUserMedia(window, browserDetails) {
   const navigator = window && window.navigator;
+  if (!navigator.mediaDevices) {
+    return;
+  }
   const MediaStreamTrack = window && window.MediaStreamTrack;
 
   navigator.getUserMedia = function(constraints, onSuccess, onError) {


### PR DESCRIPTION
since this can't work. Tentative fix for #1022

(basically #1109 finally fixed which got lost during master->main migration)