### PR TITLE
fix-polyfill WebRTC-events-when-proto-is-non-writable-but-configurable

### DIFF
--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -31,13 +31,20 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
   if (!window.RTCPeerConnection) {
     return;
   }
-  const addEventListener = Object.getOwnPropertyDescriptor(
-    EventTarget.prototype, 'addEventListener');
-  if (!addEventListener.writable) {
+
+  const proto = window.RTCPeerConnection.prototype;
+
+  const isAddEventListenerWritable =
+    tryMakePropertyWritable(proto, 'addEventListener');
+  const isRemoveEventListenerWritable =
+    tryMakePropertyWritable(proto, 'removeEventListener');
+  const canPolyfill =
+    isAddEventListenerWritable && isRemoveEventListenerWritable;
+
+  if (!canPolyfill) {
     log('Unable to polyfill events');
     return;
   }
-  const proto = window.RTCPeerConnection.prototype;
   const nativeAddEventListener = proto.addEventListener;
 
   proto.addEventListener = function(nativeEventName, cb) {
@@ -102,6 +109,28 @@ export function wrapPeerConnectionEvent(window, eventNameToWrap, wrapper) {
     enumerable: true,
     configurable: true
   });
+}
+
+/**
+ * Tries to ensure the property is writable.
+ * If the property is read-only but configurable,
+ * it will be redefined to be writable.
+ * @param {object} target the object to check the property on.
+ * @param {string} property the property to check.
+ * @return {boolean} true if the property is writable, false otherwise.
+ */
+export function tryMakePropertyWritable(target, property) {
+  try {
+    Object.defineProperty(target, property, {
+      value: target[property],
+      writable: true,
+      configurable: true,
+    });
+
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 export function disableLog(bool) {

--- a/test/unit/wrapPeerConnectionEvent.test.js
+++ b/test/unit/wrapPeerConnectionEvent.test.js
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2026 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+
+describe('wrapPeerConnectionEvent', () => {
+  const wrapPeerConnectionEvent =
+		require('../../dist/utils.js').wrapPeerConnectionEvent;
+  let window;
+  let RTCPeerConnection;
+  let addEventListener;
+  let removeEventListener;
+
+  beforeEach(() => {
+    addEventListener = jest.fn();
+    removeEventListener = jest.fn();
+    RTCPeerConnection = jest.fn();
+
+    window = {
+      RTCPeerConnection,
+    };
+  });
+
+  it('should patch RTCPeerConnection if the props are writable', () => {
+    changeAccessorDescriptor({writable: false, configurable: true});
+
+    wrapPeerConnectionEvent(window, 'track', (e) => {
+      return {type: e.type, wrapped: true};
+    });
+
+    expect(RTCPeerConnection.prototype.addEventListener)
+      .not.toBe(addEventListener);
+    expect(RTCPeerConnection.prototype.removeEventListener)
+      .not.toBe(removeEventListener);
+  });
+
+  it('shouldn\'t patch RTCPeerConnection if the props are not configurable',
+    () => {
+      changeAccessorDescriptor({writable: false, configurable: false});
+
+      wrapPeerConnectionEvent(window, 'track', () => {
+        return null;
+      });
+
+      expect(RTCPeerConnection.prototype.addEventListener)
+        .toBe(addEventListener);
+      expect(RTCPeerConnection.prototype.removeEventListener)
+        .toBe(removeEventListener);
+    });
+
+  function changeAccessorDescriptor(
+    {writable, configurable},
+  ) {
+    Object.defineProperty(RTCPeerConnection.prototype, 'addEventListener', {
+      value: addEventListener,
+      writable,
+      configurable,
+    });
+    Object.defineProperty(RTCPeerConnection.prototype, 'removeEventListener', {
+      value: removeEventListener,
+      writable,
+      configurable,
+    });
+  }
+});
+


### PR DESCRIPTION
## Summary

Fix `wrapPeerConnectionEvent` so it does not skip event polyfilling when `RTCPeerConnection.prototype` event listener methods are non-writable but still configurable through Object.defineProperty.

## Background

I found this issue while testing a WebRTC application embedded in Wix.

The current implementation checks the descriptor of `EventTarget.prototype.addEventListener`, but the polyfill actually patches methods on `RTCPeerConnection.prototype`:

```js
proto.addEventListener = function(nativeEventName, cb) { ... };
proto.removeEventListener = function(nativeEventName, cb) { ... };
```

In some browsers or environments, these properties can behave as read-only, so direct assignment throws a `TypeError`:

```text
Cannot assign to read only property 'addEventListener' of object '#<RTCPeerConnection>'
```

The latest adapter version avoids the crash by checking whether `EventTarget.prototype.addEventListener` is writable before applying the polyfill. However, that check is not enough to determine whether `RTCPeerConnection.prototype` can actually be patched.

This is a known issue that has been reported in other contexts as well:

- [LiveKit client-sdk-js #1806](https://github.com/livekit/client-sdk-js/issues/1806)

## Reproduction

This can be reproduced with this Wix test page:

- [example](https://johnnynabetes.wixsite.com/sdk-fix)

By default, the page loads with the polyfill fix applied. To disable the fix and reproduce the original error, run this in the browser console:

```js
localStorage.setItem('error-test', true);
```

Then reload the page. You will see the crash in the console.

**Important**: Because the test page uses an old version that does not have the `EventTarget.prototype` descriptor check, the issue was loud and visible. The latest version of adapter does not crash, but it also does not apply the polyfill.

A minimal code example to illustrate the underlying JavaScript behavior:

```js
(function () {
  'use strict';

  const object = {};

  Object.defineProperty(object, 'readonly', {
    value: false,
    writable: false,
    configurable: true,
  });

  // This throws because the property is read-only.
  object.readonly = someNewValue();
})();
```

However, even when a property is non-writable, it can still be redefined:

```js
Object.defineProperty(object, 'readonly', {
  value: someNewValue(),
  writable: true,
  configurable: true,
});
```

## Root Cause

The old guard checked `EventTarget.prototype.addEventListener.writable` globally:

```js
const addEventListener = Object.getOwnPropertyDescriptor(
  EventTarget.prototype,
  'addEventListener'
);

if (!addEventListener.writable) {
  return;
}
```

The main issue is that the `EventTarget.prototype.addEventListener` is not writeable, cannot be assigned... but the target `RTCPeerConnection.prototype` can still define its own `addEventListener` 

## Fix

Introduce `tryMakePropertyWritable`, which attempts to redefine the target property as writable before applying the polyfill.

Instead of relying on direct assignment, it uses `Object.defineProperty`:

```js
Object.defineProperty(target, property, {
  value: target[property],
  writable: true,
  configurable: true,
});
```

If the property can be redefined, the helper returns `true`. If the property is truly locked, it catches the error and returns `false`.

The polyfill now only proceeds when both required methods can be prepared:

```js
  const isAddEventListenerWritable = tryMakePropertyWritable(proto, 'addEventListener');
  const isRemoveEventListenerWritable = tryMakePropertyWritable(proto, 'removeEventListener');
  const canPolyfill = isAddEventListenerWritable && isRemoveEventListenerWritable;

  if (!canPolyfill) {
    log('Unable to polyfill events');
    return;
  }
```

This makes the check more accurate because it validates the actual prototype being patched.

## Behavior Before

```js
const addEventListener = Object.getOwnPropertyDescriptor(
  EventTarget.prototype,
  'addEventListener'
);

if (!addEventListener.writable) {
  return;
}
```

The polyfill could be skipped based on the descriptor of `EventTarget.prototype`, even though the actual patch target was `RTCPeerConnection.prototype`.

## Behavior After

```js
const proto = window.RTCPeerConnection.prototype;

const canPolyfill =
  tryMakePropertyWritable(proto, 'addEventListener') &&
  tryMakePropertyWritable(proto, 'removeEventListener');

if (!canPolyfill) {
  log('Unable to polyfill events');
  return;
}
```

The polyfill now checks whether the actual target can be patched before replacing the event listener methods.

## Test Plan

Added unit tests for `wrapPeerConnectionEvent` covering:

- **Configurable properties**
  - `addEventListener` and `removeEventListener` can be redefined.
  - The polyfill is applied successfully.
  - Events are transformed before reaching the listener.

- **Non-configurable properties**
  - The polyfill does not throw.
  - The prototype is left untouched.
  - Native callbacks continue to work without wrapping.