### PR TITLE
test: do not leave an empty line when removing a=max-message-size

### DIFF
--- a/test/e2e/maxMessageSize.js
+++ b/test/e2e/maxMessageSize.js
@@ -45,7 +45,7 @@ describe('maxMessageSize', () => {
       return {
         type: description.type,
         sdp: description.sdp
-          .replace(/^a=max-message-size:\s*(\d+)\s*$/gm, '')
+          .replace(/^a=max-message-size:\s*(\d+)\s*\r?\n/gm, '')
           .replace(/(^m=application\s+\d+\s+[\w/]*SCTP.*$)/m,
             '$1\r\na=max-message-size:' + maxMessageSize),
       };


### PR DESCRIPTION
The regex used /^a=max-message-size:...\s*$/gm which, because $ matches before the newline in multiline mode, removed the line content but left its \n behind. This only worked because a=max-message-size used to be the last attribute of the SCTP m-section so the stray newline ended up at the end of the SDP where it is tolerated.

Chrome 153 adds a=sctp-init after it which turns the stray newline into an empty line in the middle of the section and setRemoteDescription fails with "Invalid SDP line".