### PR TITLE
test: run the e2e tests in Safari on github actions

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -25,3 +25,16 @@ jobs:
         BVER: ${{matrix.version}}
         DISPLAY: :99.0
       run: npm run e2e-tests
+
+  safari:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+    - run: npm install
+    - name: enable safaridriver
+      run: sudo safaridriver --enable
+    - name: e2e-tests
+      env:
+        BROWSER: safari
+      run: npm run e2e-tests

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "karma-firefox-launcher": "^1.3.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.3",
-    "karma-safari-launcher": "^1.0.0",
+    "karma-webdriver-launcher": "^1.0.8",
     "mocha": "^10.2.0"
   }
 }

--- a/test/e2e/addTrack.js
+++ b/test/e2e/addTrack.js
@@ -27,7 +27,7 @@ describe('addTrack', () => {
           const again = () => {
             pc.addTrack(stream.getTracks()[0], stream);
           };
-          expect(again).to.throw(/already/)
+          expect(again).to.throw()
             .that.has.property('name').that.equals('InvalidAccessError');
         });
     });
@@ -39,7 +39,7 @@ describe('addTrack', () => {
           const again = () => {
             pc.addTrack(stream.getTracks()[0], stream);
           };
-          expect(again).to.throw(/already/)
+          expect(again).to.throw()
             .that.has.property('name').that.equals('InvalidAccessError');
         });
     });
@@ -52,7 +52,7 @@ describe('addTrack', () => {
           const again = () => {
             pc.addStream(stream);
           };
-          expect(again).to.throw(/already/)
+          expect(again).to.throw()
             .that.has.property('name').that.equals('InvalidAccessError');
         });
     });
@@ -64,7 +64,7 @@ describe('addTrack', () => {
           const afterClose = () => {
             pc.addTrack(stream.getTracks()[0], stream);
           };
-          expect(afterClose).to.throw(/closed/)
+          expect(afterClose).to.throw()
             .that.has.property('name').that.equals('InvalidStateError');
         });
     });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -10,7 +10,12 @@
 
 const os = require('os');
 const path = require('path');
+const http = require('http');
+const {spawn} = require('child_process');
 const puppeteerBrowsers = require('@puppeteer/browsers');
+
+const SAFARIDRIVER_BIN = process.env.SAFARIDRIVER_BIN ||
+    '/usr/bin/safaridriver';
 
 async function download(browser, version, cacheDir, platform) {
   const buildId = await puppeteerBrowsers
@@ -22,6 +27,39 @@ async function download(browser, version, cacheDir, platform) {
     platform
   });
   return buildId;
+}
+
+function isListening(port) {
+  return new Promise((resolve) => {
+    const request = http.get({host: '127.0.0.1', port, path: '/status'},
+      (response) => {
+        response.resume();
+        resolve(response.statusCode === 200);
+      });
+    request.on('error', () => resolve(false));
+  });
+}
+
+// Starts safaridriver, Safari's WebDriver server. Safari replaces the actual
+// capture devices with mock devices when it is driven by WebDriver and does
+// not show a permission prompt which is what makes it testable on machines
+// without a camera such as CI runners.
+// Note that safaridriver needs to be enabled once per machine by running
+//   sudo safaridriver --enable
+async function startSafariDriver(port) {
+  const child = spawn(SAFARIDRIVER_BIN, ['-p', port], {stdio: 'inherit'});
+  child.on('error', (error) => {
+    console.error('Failed to start safaridriver: ' + error.message);
+  });
+  process.on('exit', () => child.kill());
+
+  for (let i = 0; i < 40; i++) {
+    if (await isListening(port)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('safaridriver is not listening on port ' + port);
 }
 
 module.exports = async(config) => {
@@ -45,11 +83,9 @@ module.exports = async(config) => {
     browsers = ['chrome', 'firefox'];
   }
 
-  // uses Safari Technology Preview.
-  if (browsers.includes('Safari') && os.platform() === 'darwin' &&
-      process.env.BVER === 'unstable' && !process.env.SAFARI_BIN) {
-    process.env.SAFARI_BIN = '/Applications/Safari Technology Preview.app' +
-        '/Contents/MacOS/Safari Technology Preview';
+  const safariDriverPort = parseInt(process.env.SAFARIDRIVER_PORT || 4444, 10);
+  if (browsers.includes('Safari')) {
+    await startSafariDriver(safariDriverPort);
   }
 
   if (browsers.includes('firefox')) {
@@ -100,6 +136,17 @@ module.exports = async(config) => {
       electron: {
         base: 'Electron',
         flags: ['--use-fake-device-for-media-stream']
+      },
+      Safari: {
+        base: 'WebDriver',
+        // safaridriver serves the WebDriver API at / while wd defaults
+        // to the /wd/hub path used by the selenium standalone server.
+        config: {hostname: '127.0.0.1', port: safariDriverPort, path: '/'},
+        browserName: 'safari',
+        // safaridriver only speaks the W3C protocol and does not accept
+        // the legacy capabilities wd sends by default.
+        forceW3C: true,
+        'wd-no-defaults': true
       },
       firefox: {
         base: 'Firefox',


### PR DESCRIPTION
Safari only provides mock capture devices (and skips the permission prompt) when it is driven via WebDriver which makes it testable on a CI runner without a camera. Replace karma-safari-launcher, which opens Safari as a regular browser, with karma-webdriver-launcher talking to a safaridriver instance started by the karma config.

(lets try this, better than no CI coverage)