### PR TITLE
safari : drop local streams in Safari when the last track is removed

### DIFF
--- a/src/js/safari/safari_shim.js
+++ b/src/js/safari/safari_shim.js
@@ -51,6 +51,24 @@ export function shimLocalStreamsAPI(window) {
         }
         return _addTrack.apply(this, arguments);
       };
+
+    if ('removeTrack' in window.RTCPeerConnection.prototype) {
+      const _removeTrack = window.RTCPeerConnection.prototype.removeTrack;
+      window.RTCPeerConnection.prototype.removeTrack =
+        function removeTrack(sender) {
+          const track = sender && sender.track;
+          const result = _removeTrack.apply(this, arguments);
+          // Drop streams none of whose tracks are sent anymore. Other
+          // browsers do this in their legacy getLocalStreams shim.
+          if (track && this._localStreams) {
+            const tracks = this.getSenders().map(s => s.track);
+            this._localStreams = this._localStreams.filter(
+              stream => !stream.getTracks().includes(track) ||
+                  stream.getTracks().some(t => tracks.includes(t)));
+          }
+          return result;
+        };
+    }
   }
   if (!('removeStream' in window.RTCPeerConnection.prototype)) {
     window.RTCPeerConnection.prototype.removeStream =

--- a/test/unit/safari.test.js
+++ b/test/unit/safari.test.js
@@ -18,6 +18,9 @@ describe('Safari shim', () => {
   describe('shimStreamsAPI', () => {
     beforeEach(() => {
       window.RTCPeerConnection.prototype.addTrack = jest.fn();
+      window.RTCPeerConnection.prototype.removeTrack = jest.fn((sender) => {
+        sender.track = null;
+      });
       shim.shimLocalStreamsAPI(window);
       shim.shimRemoteStreamsAPI(window);
     });
@@ -65,6 +68,29 @@ describe('Safari shim', () => {
       expect(pc.getLocalStreams()[0]).toBe(stream);
 
       pc.removeStream(stream);
+      expect(pc.getLocalStreams().length).toBe(0);
+    });
+
+    it('removeTrack removes the stream after the last track', () => {
+      const pc = new window.RTCPeerConnection();
+      const audioTrack = {id: 'audio'};
+      const videoTrack = {id: 'video'};
+      const stream = {
+        id: 'id1',
+        getTracks: () => [audioTrack, videoTrack],
+        getAudioTracks: () => [audioTrack],
+        getVideoTracks: () => [videoTrack],
+      };
+      const senders = [{track: audioTrack}, {track: videoTrack}];
+      pc.getSenders = () => senders;
+
+      pc.addStream(stream);
+      expect(pc.getLocalStreams().length).toBe(1);
+
+      pc.removeTrack(senders[0]);
+      expect(pc.getLocalStreams().length).toBe(1);
+
+      pc.removeTrack(senders[1]);
       expect(pc.getLocalStreams().length).toBe(0);
     });
   });


### PR DESCRIPTION
Safari's getLocalStreams shim kept streams around after all their tracks had been removed via removeTrack while Chrome's legacy shim drops them.