### PR TITLE
safari: don't shim maxMessageSize when RTCSctpTransport is native

### DIFF
--- a/src/js/common_shim.js
+++ b/src/js/common_shim.js
@@ -105,6 +105,12 @@ export function shimMaxMessageSize(window, browserDetails) {
     // https://bugzilla.mozilla.org/show_bug.cgi?id=1278299
     return;
   }
+  if (browserDetails.browser === 'safari' &&
+      'sctp' in window.RTCPeerConnection.prototype) {
+    // Native RTCSctpTransport. The sctp getter below is not installed in
+    // that case so nothing can read what setRemoteDescription computes.
+    return;
+  }
 
   if (!('sctp' in window.RTCPeerConnection.prototype)) {
     Object.defineProperty(window.RTCPeerConnection.prototype, 'sctp', {

--- a/test/unit/maxmessagesize.test.js
+++ b/test/unit/maxmessagesize.test.js
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2026 The adapter.js project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree.
+ */
+describe('maxMessageSize', () => {
+  const shim = require('../../dist/common_shim');
+  let window;
+  let origSetRemoteDescription;
+  beforeEach(() => {
+    window = {
+      RTCPeerConnection: jest.fn(),
+    };
+    origSetRemoteDescription = jest.fn();
+    window.RTCPeerConnection.prototype.setRemoteDescription =
+      origSetRemoteDescription;
+  });
+
+  // Simulates a native RTCSctpTransport being exposed as pc.sctp.
+  function shimNativeSctp() {
+    Object.defineProperty(window.RTCPeerConnection.prototype, 'sctp', {
+      get() {
+        return null;
+      },
+      configurable: true,
+    });
+  }
+
+  describe('does nothing if', () => {
+    it('RTCPeerConnection is not defined', () => {
+      expect(() => shim.shimMaxMessageSize({}, {})).not.toThrow();
+    });
+  });
+
+  describe('Safari behaviour', () => {
+    const browserDetails = {browser: 'safari', version: 605};
+
+    it('does not wrap setRemoteDescription when sctp is supported', () => {
+      shimNativeSctp();
+      shim.shimMaxMessageSize(window, browserDetails);
+
+      expect(window.RTCPeerConnection.prototype.setRemoteDescription)
+        .toBe(origSetRemoteDescription);
+    });
+
+    it('wraps setRemoteDescription when sctp is not supported', () => {
+      shim.shimMaxMessageSize(window, browserDetails);
+
+      expect(window.RTCPeerConnection.prototype.setRemoteDescription)
+        .not.toBe(origSetRemoteDescription);
+      expect(window.RTCPeerConnection.prototype).toHaveProperty('sctp');
+    });
+  });
+});


### PR DESCRIPTION
Unlike Chrome and Firefox, Safari has no gate in shimMaxMessageSize, so the setRemoteDescription wrapper is installed unconditionally. When pc.sctp is native the getter it feeds is not installed, which means the value parsed out of every remote description can not be read by anyone -- and it disagrees with what apps actually see (65536 vs the native 262144 in WebKit 26).

Gate on the presence of the attribute rather than a version so old Safari keeps the shim.

